### PR TITLE
Add MetaCall core library and API headers

### DIFF
--- a/source/metacall/CMakeLists.txt
+++ b/source/metacall/CMakeLists.txt
@@ -1,0 +1,281 @@
+#
+# Library name and options
+#
+
+# Target name
+set(target metacall)
+
+# Exit here if required dependencies are not met
+message(STATUS "Lib ${target}")
+
+# Set API export file and macro
+string(TOUPPER ${target} target_upper)
+set(export_file  "include/${target}/${target}_api.h")
+set(export_macro "${target_upper}_API")
+
+#
+# Compiler warnings
+#
+
+include(Warnings)
+
+#
+# Compiler security
+#
+
+include(SecurityFlags)
+
+#
+# Configure templates
+#
+
+if(OPTION_FORK_SAFE)
+	set(METACALL_FORK_SAFE 1)
+endif()
+
+if(OPTION_THREAD_SAFE)
+	set(METACALL_THREAD_SAFE 1)
+endif()
+
+set(include_bin_path ${CMAKE_CURRENT_BINARY_DIR}/include/${target})
+
+# Generate loaders plugin header
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/metacall_def.h.in ${include_bin_path}/metacall_def.h)
+
+#
+# Sources
+#
+
+set(include_path "${CMAKE_CURRENT_SOURCE_DIR}/include/${target}")
+set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
+
+set(headers
+	${include_bin_path}/metacall_def.h
+	${include_path}/metacall.h
+	${include_path}/metacall_value.h
+	${include_path}/metacall_log.h
+	${include_path}/metacall_allocator.h
+	${include_path}/metacall_error.h
+	${include_path}/metacall_link.h
+)
+
+set(sources
+	${source_path}/metacall.c
+	${source_path}/metacall_value.c
+	${source_path}/metacall_log.c
+	${source_path}/metacall_allocator.c
+	${source_path}/metacall_error.c
+	${source_path}/metacall_link.c
+)
+
+if(OPTION_FORK_SAFE)
+	set(headers ${headers}
+		${include_path}/metacall_fork.h
+	)
+	set(sources ${sources}
+		${source_path}/metacall_fork.c
+	)
+endif()
+
+# Group source files
+set(header_group "Header Files (API)")
+set(source_group "Source Files")
+source_group_by_path(${include_path} "\\\\.h$|\\\\.hpp$"
+	${header_group} ${headers})
+source_group_by_path(${source_path}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
+	${source_group} ${sources})
+
+#
+# Create library
+#
+
+# Include here any library which metacall depends on
+set(unity_build_depends
+	version
+	preprocessor
+	environment
+	format
+	threading
+	log
+	memory
+	portability
+	adt
+	filesystem
+	dynlink
+	plugin
+	detour
+	reflect
+	serial
+	configuration
+	loader
+)
+
+set(unity_build_source_list)
+set(unity_build_definition_list)
+set(unity_build_include_list)
+
+foreach(tgt ${unity_build_depends})
+	# Get target source files
+	get_target_property(target_sources
+		${META_PROJECT_NAME}::${tgt}
+		SOURCES
+	)
+
+	set(unity_build_source_list
+		${unity_build_source_list}
+		${target_sources}
+	)
+
+	# Set target definitions
+	set(unity_build_definition_list
+		${unity_build_definition_list}
+		$<TARGET_PROPERTY:${META_PROJECT_NAME}::${tgt},COMPILE_DEFINITIONS>
+	)
+
+	# Set target include paths
+	set(unity_build_include_list
+		${unity_build_include_list}
+		$<TARGET_PROPERTY:${META_PROJECT_NAME}::${tgt},INCLUDE_DIRECTORIES>
+	)
+endforeach()
+
+# Build library
+add_library(${target}
+	${unity_build_source_list}
+	${sources}
+	${headers}
+)
+
+# Create namespaced alias
+add_library(${META_PROJECT_NAME}::${target} ALIAS ${target})
+
+# Export library for downstream projects
+export(TARGETS ${target} NAMESPACE ${META_PROJECT_NAME}:: FILE ${PROJECT_BINARY_DIR}/cmake/${target}/${target}-export.cmake)
+
+# Create API export header
+generate_export_header(${target}
+	EXPORT_FILE_NAME  ${export_file}
+	EXPORT_MACRO_NAME ${export_macro}
+)
+
+#
+# Project options
+#
+
+set_target_properties(${target}
+	PROPERTIES
+	${DEFAULT_PROJECT_OPTIONS}
+	FOLDER "${IDE_FOLDER}"
+)
+
+#
+# Include directories
+#
+
+target_include_directories(${target}
+	PRIVATE
+	# Dependencies Includes
+	${unity_build_include_list}
+
+	${PROJECT_BINARY_DIR}/source/include
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/include
+
+	PUBLIC
+	${DEFAULT_INCLUDE_DIRECTORIES}
+
+	INTERFACE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+	$<INSTALL_INTERFACE:include>
+)
+
+#
+# Libraries
+#
+
+target_link_libraries(${target}
+	PRIVATE
+
+	PUBLIC
+	${DEFAULT_LIBRARIES}
+
+	$<$<BOOL:${BUILD_SHARED_LIBS}>:${CMAKE_DL_LIBS}> # Native dynamic load library
+
+	# Fix issues with atomics in armv6 and armv7
+	$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},armv7l>:-latomic>
+
+	INTERFACE
+)
+
+#
+# Compile definitions
+#
+
+target_compile_definitions(${target}
+	PRIVATE
+	# Dependencies Export API
+	${unity_build_definition_list}
+
+	# MetaCall Export API
+	${target_upper}_EXPORTS
+
+	$<$<BOOL:${OPTION_FORK_SAFE}>:${target_upper}_FORK_SAFE>
+	$<$<BOOL:${OPTION_THREAD_SAFE}>:${target_upper}_THREAD_SAFE>
+
+	PUBLIC
+	$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${target_upper}_STATIC_DEFINE>
+	${DEFAULT_COMPILE_DEFINITIONS}
+
+	INTERFACE
+)
+
+#
+# Compile options
+#
+
+target_compile_options(${target}
+	PRIVATE
+
+	PUBLIC
+	${DEFAULT_COMPILE_OPTIONS}
+
+	INTERFACE
+)
+
+#
+# Linker options
+#
+
+target_link_options(${target}
+	PRIVATE
+
+	PUBLIC
+	${DEFAULT_LINKER_OPTIONS}
+
+	INTERFACE
+)
+
+#
+# Deployment
+#
+
+# Header files
+install(DIRECTORY
+	${CMAKE_CURRENT_SOURCE_DIR}/include/${target} DESTINATION ${INSTALL_INCLUDE}
+	COMPONENT dev
+)
+
+# Generated header files
+install(DIRECTORY
+	${CMAKE_CURRENT_BINARY_DIR}/include/${target} DESTINATION ${INSTALL_INCLUDE}
+	COMPONENT dev
+)
+
+# CMake config
+install(TARGETS ${target}
+	EXPORT  "${target}-export"				COMPONENT dev
+	RUNTIME DESTINATION ${INSTALL_BIN}		COMPONENT runtime
+	LIBRARY DESTINATION ${INSTALL_SHARED}	COMPONENT runtime
+	ARCHIVE DESTINATION ${INSTALL_LIB}		COMPONENT dev
+)

--- a/source/metacall/include/metacall/metacall.h
+++ b/source/metacall/include/metacall/metacall.h
@@ -1,0 +1,1556 @@
+
+
+#ifndef METACALL_H
+#define METACALL_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#include <metacall/metacall_allocator.h>
+#include <metacall/metacall_def.h>
+#include <metacall/metacall_error.h>
+#include <metacall/metacall_link.h>
+#include <metacall/metacall_log.h>
+#include <metacall/metacall_value.h>
+#include <metacall/metacall_version.h>
+
+#ifdef METACALL_FORK_SAFE
+	#include <metacall/metacall_fork.h>
+#endif /* METACALL_FORK_SAFE */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Headers -- */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/* -- Definitions -- */
+
+#define METACALL_FLAGS_FORK_SAFE 0x01 << 0x00
+
+/* -- Forward Declarations -- */
+
+struct metacall_initialize_configuration_type;
+
+/* -- Type Definitions -- */
+
+struct metacall_initialize_configuration_type
+{
+	const char *tag; /* Tag referring to the loader */
+	void *options;	 /* Value of type Map that will be merged merged into the configuration of the loader */
+};
+
+typedef void *(*metacall_await_callback)(void *, void *);
+
+typedef struct metacall_await_callbacks_type
+{
+	metacall_await_callback resolve;
+	metacall_await_callback reject;
+
+} metacall_await_callbacks;
+
+struct metacall_version_type
+{
+	unsigned int major;
+	unsigned int minor;
+	unsigned int patch;
+	const char *revision;
+	const char *str;
+	const char *name;
+};
+
+/* -- Global Variables -- */
+
+METACALL_API extern void *metacall_null_args[1];
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Returns default serializer used by MetaCall
+*
+*  @return
+*    Name of the serializer to be used with serialization methods
+*/
+METACALL_API const char *metacall_serial(void);
+
+/**
+*  @brief
+*    Returns default detour used by MetaCall
+*
+*  @return
+*    Name of the detour to be used with detouring methods
+*/
+METACALL_API const char *metacall_detour(void);
+
+/**
+*  @brief
+*    Disables MetaCall logs, must be called before @metacall_initialize.
+*
+*   When initializing MetaCall, it initializes a default logs to stdout
+*   if none was defined. If you want to benchmark or simply disable this
+*   default logs, you can call to this function before @metacall_initialize.
+*/
+METACALL_API void metacall_log_null(void);
+
+/**
+*  @brief
+*    Flags to be set in MetaCall library
+*
+*  @param[in] flags
+*    Combination of flags referring to definitions METACALL_FLAGS_*
+*/
+METACALL_API void metacall_flags(int flags);
+
+/**
+*  @brief
+*    Initialize MetaCall library
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_initialize(void);
+
+/**
+*  @brief
+*    Initialize MetaCall library with configuration arguments
+*
+*  @param[in] initialize_config
+*    Extension of the script to be loaded in memory with data to be injected
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_initialize_ex(struct metacall_initialize_configuration_type initialize_config[]);
+
+/**
+*  @brief
+*    Initialize MetaCall application arguments
+*
+*  @param[in] argc
+*    Number of additional parameters to be passed to the runtime when initializing
+*
+*  @param[in] argv
+*    Additional parameters to be passed to the runtime when initializing (when using MetaCall as an application)
+*/
+METACALL_API void metacall_initialize_args(int argc, char *argv[]);
+
+/**
+*  @brief
+*    Get the number of arguments in which MetaCall was initialized
+*
+*  @return
+*    An integer equal or greater than zero
+*/
+METACALL_API int metacall_argc(void);
+
+/**
+*  @brief
+*    Get the arguments in which MetaCall was initialized
+*
+*  @return
+*    A pointer to an array of strings with the additional arguments
+*/
+METACALL_API char **metacall_argv(void);
+
+/**
+*  @brief
+*    Check if script context is loaded by @tag
+*
+*  @param[in] tag
+*    Extension of the script (if tag is NULL, it returns the status of the whole MetaCall instance)
+*
+*  @return
+*    Zero if context is initialized, different from zero otherwise
+*/
+METACALL_API int metacall_is_initialized(const char *tag);
+
+/**
+*  @brief
+*    Amount of function call arguments supported by MetaCall
+*
+*  @return
+*    Number of arguments suported
+*/
+METACALL_API size_t metacall_args_size(void);
+
+/**
+*  @brief
+*    Set a execution path defined by @path to the extension script @tag
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] path
+*    Path to be loaded
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_execution_path(const char *tag, const char *path);
+
+/**
+*  @brief
+*    Set a execution path defined by @path to the extension script @tag with length
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] tag_length
+*    Length of the extension of the tag
+*
+*  @param[in] path
+*    Path to be loaded
+*
+*  @param[in] path_length
+*    Length of the path
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_execution_path_s(const char *tag, size_t tag_length, const char *path, size_t path_length);
+
+/**
+*  @brief
+*    Loads a script from file specified by @path
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] paths
+*    Path array of files
+*
+*  @param[in] size
+*    Size of the array @paths
+*
+*  @param[inout] handle
+*    Optional pointer to reference of loaded handle. If the parameter is NULL, the symbols loaded are
+*    propagated to the loader scope (i.e they will share the scope between all previously loaded files and they can collide).
+*    Otherwise, if we pass a void* pointer set to NULL, it will behave as output parameter, obtaining the reference to the
+*    created handle, which can be later on used for calling to functions of that handle. The symbols will not be propagated
+*    to the loader scope and they will be private (this prevents collisions). The last case is if we pass an already allocated
+*    handle (i.e a void* pointer pointing to an previously loaded handle), then in this case, the symbols loaded will be propagated
+*    to the previously allocated handle, and it will behave as a in parameter.
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_load_from_file(const char *tag, const char *paths[], size_t size, void **handle);
+
+/**
+*  @brief
+*    Loads a script from memory
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] buffer
+*    Memory block representing the string of the script
+*
+*  @param[in] size
+*    Memory block representing the string of the script
+*
+*  @param[inout] handle
+*    Optional pointer to reference of loaded handle. If the parameter is NULL, the symbols loaded are
+*    propagated to the loader scope (i.e they will share the scope between all previously loaded files and they can collide).
+*    Otherwise, if we pass a void* pointer set to NULL, it will behave as output parameter, obtaining the reference to the
+*    created handle, which can be later on used for calling to functions of that handle. The symbols will not be propagated
+*    to the loader scope and they will be private (this prevents collisions). The last case is if we pass an already allocated
+*    handle (i.e a void* pointer pointing to an previously loaded handle), then in this case, the symbols loaded will be propagated
+*    to the previously allocated handle, and it will behave as a in parameter.
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_load_from_memory(const char *tag, const char *buffer, size_t size, void **handle);
+
+/**
+*  @brief
+*    Loads a package of scrips from file specified by @path into loader defined by @extension
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] path
+*    Path of the package
+*
+*  @param[inout] handle
+*    Optional pointer to reference of loaded handle. If the parameter is NULL, the symbols loaded are
+*    propagated to the loader scope (i.e they will share the scope between all previously loaded files and they can collide).
+*    Otherwise, if we pass a void* pointer set to NULL, it will behave as output parameter, obtaining the reference to the
+*    created handle, which can be later on used for calling to functions of that handle. The symbols will not be propagated
+*    to the loader scope and they will be private (this prevents collisions). The last case is if we pass an already allocated
+*    handle (i.e a void* pointer pointing to an previously loaded handle), then in this case, the symbols loaded will be propagated
+*    to the previously allocated handle, and it will behave as a in parameter.
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_load_from_package(const char *tag, const char *path, void **handle);
+
+/**
+*  @brief
+*    Loads a a list of scrips from configuration specified by @path into loader
+*    with the following format:
+*        {
+*            "language_id": "<tag>",
+*            "path": "<path>",
+*            "scripts": [ "<script0>", "<script1>", ..., "<scriptN>" ]
+*        }
+*
+*  @param[in] path
+*    Path of the configuration
+*
+*  @param[inout] handle
+*    Optional pointer to reference of loaded handle. If the parameter is NULL, the symbols loaded are
+*    propagated to the loader scope (i.e they will share the scope between all previously loaded files and they can collide).
+*    Otherwise, if we pass a void* pointer set to NULL, it will behave as output parameter, obtaining the reference to the
+*    created handle, which can be later on used for calling to functions of that handle. The symbols will not be propagated
+*    to the loader scope and they will be private (this prevents collisions). The last case is if we pass an already allocated
+*    handle (i.e a void* pointer pointing to an previously loaded handle), then in this case, the symbols loaded will be propagated
+*    to the previously allocated handle, and it will behave as a in parameter.
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the configuration
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_load_from_configuration(const char *path, void **handle, void *allocator);
+
+/**
+*  @brief
+*    Call a function anonymously by value array @args
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallv(const char *name, void *args[]);
+
+/**
+*  @brief
+*    Call a function anonymously by value array @args
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of the call
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallv_s(const char *name, void *args[], size_t size);
+
+/**
+*  @brief
+*    Call a function anonymously by handle @handle value array @args
+*    This function allows to avoid name collisions when calling functions by name
+*
+*  @param[in] handle
+*    Handle where the function belongs
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallhv(void *handle, const char *name, void *args[]);
+
+/**
+*  @brief
+*    Call a function anonymously by handle @handle value array @args
+*    This function allows to avoid name collisions when calling functions by name
+*    Includes @size in order to allow variadic arguments or safe calls
+*
+*  @param[in] handle
+*    Handle where the function belongs
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of the call
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallhv_s(void *handle, const char *name, void *args[], size_t size);
+
+/**
+*  @brief
+*    Call a function anonymously by variable arguments @va_args
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] va_args
+*    Varidic function parameters
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacall(const char *name, ...);
+
+/**
+*  @brief
+*    Call a function anonymously by type array @ids and variable arguments @va_args
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] ids
+*    Array of types refered to @va_args
+*
+*  @param[in] va_args
+*    Varidic function parameters
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallt(const char *name, const enum metacall_value_id ids[], ...);
+
+/**
+*  @brief
+*    Call a function anonymously by type array @ids and variable arguments @va_args
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] ids
+*    Array of types refered to @va_args
+*
+*  @param[in] size
+*    Number of elements of the call
+*
+*  @param[in] va_args
+*    Varidic function parameters
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallt_s(const char *name, const enum metacall_value_id ids[], size_t size, ...);
+
+/**
+*  @brief
+*    Call a function anonymously by type array @ids and variable arguments @va_args
+*
+*  @param[in] handle
+*    Pointer to the handle returned by metacall_load_from_{file, memory, package}
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @param[in] ids
+*    Array of types refered to @va_args
+*
+*  @param[in] size
+*    Number of elements of the call
+*
+*  @param[in] va_args
+*    Varidic function parameters
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallht_s(void *handle, const char *name, const enum metacall_value_id ids[], size_t size, ...);
+
+/**
+*  @brief
+*    Get the function by @name
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @return
+*    Function reference, null if the function does not exist
+*/
+METACALL_API void *metacall_function(const char *name);
+
+/**
+*  @brief
+*    Create an empty handler into a loader with name @name
+*
+*  @param[in] loader
+*    Pointer to the loader which the handle belongs to
+*
+*  @param[in] name
+*    Name of the handle
+*
+*  @param[out] handle_ptr
+*    On success, returns the pointer to the handle created, otherwise NULL
+*
+*  @return
+*    Return zero on success, different from zero on error
+*/
+METACALL_API int metacall_handle_initialize(void *loader, const char *name, void **handle_ptr);
+
+/**
+*  @brief
+*    Populate the objects of @handle_src into @handle_dest
+*
+*  @param[inout] handle_dest
+*    Handle where the objects from @handle_src will be stored
+*
+*  @param[in] handle_src
+*    Handle from where the objects will be copied
+*
+*  @return
+*    Return zero on success, different from zero on error
+*/
+METACALL_API int metacall_handle_populate(void *handle_dest, void *handle_src);
+
+/**
+*  @brief
+*    Get the function by @name from @handle
+*
+*  @param[in] handle
+*    Pointer to the handle returned by metacall_load_from_{file, memory, package}
+*
+*  @param[in] name
+*    Name of the function
+*
+*  @return
+*    Function reference, null if the function does not exist
+*/
+METACALL_API void *metacall_handle_function(void *handle, const char *name);
+
+/**
+*  @brief
+*    Get the function parameter type id
+*
+*  @param[in] func
+*    The pointer to the function obtained from metacall_function
+*
+*  @param[in] parameter
+*    The index of the parameter to be retrieved
+*
+*  @param[out] id
+*    The parameter type id that will be returned
+*
+*  @return
+*    Return 0 if the @parameter index exists and @func is valid, 1 otherwhise
+*/
+METACALL_API int metacall_function_parameter_type(void *func, size_t parameter, enum metacall_value_id *id);
+
+/**
+*  @brief
+*    Get the function return type id
+*
+*  @param[in] func
+*    The pointer to the function obtained from metacall_function
+*
+*
+*  @param[out] id
+*    The value id of the return type of the function @func
+*
+*  @return
+*    Return 0 if the @func is valid, 1 otherwhise
+*/
+METACALL_API int metacall_function_return_type(void *func, enum metacall_value_id *id);
+
+/**
+*  @brief
+*    Get minimun mumber of arguments accepted by function @func
+*
+*  @param[in] func
+*    Function reference
+*
+*  @return
+*    Return mumber of arguments
+*/
+METACALL_API size_t metacall_function_size(void *func);
+
+/**
+*  @brief
+*    Check if the function @func is asynchronous or synchronous
+*
+*  @param[in] func
+*    Function reference
+*
+*  @return
+*    Return 0 if it is syncrhonous, 1 if it is asynchronous and -1 if the function is NULL
+*/
+METACALL_API int metacall_function_async(void *func);
+
+/**
+*  @brief
+*    Get the handle by @name
+*
+*  @param[in] tag
+*    Extension of the script
+*
+*  @param[in] name
+*    Name of the handle
+*
+*  @return
+*    Handle reference, null if the function does not exist
+*/
+METACALL_API void *metacall_handle(const char *tag, const char *name);
+
+/**
+*  @brief
+*    Get name of a @handle
+*
+*  @param[in] handle
+*    Pointer to the handle to be retrieved
+*
+*  @return
+*    String that references the handle
+*/
+METACALL_API const char *metacall_handle_id(void *handle);
+
+/**
+*  @brief
+*    Return a value representing the handle as a map of functions (or values)
+*
+*  @param[in] handle
+*    Reference to the handle to be described
+*
+*  @return
+*    A value of type map on success, null otherwise
+*/
+METACALL_API void *metacall_handle_export(void *handle);
+
+/**
+*  @brief
+*    Call a function anonymously by value array @args and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallfv(void *func, void *args[]);
+
+/**
+*  @brief
+*    Call a function anonymously by value array @args and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of function arguments
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallfv_s(void *func, void *args[], size_t size);
+
+/**
+*  @brief
+*    Call a function anonymously by variable arguments @va_args and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallf(void *func, ...);
+
+/**
+*  @brief
+*    Call a function anonymously by function @func and serial @buffer of size @size
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] buffer
+*    String representing an array to be deserialized into arguments of the function
+*
+*  @param[in] size
+*    Size of string @buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the value
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallfs(void *func, const char *buffer, size_t size, void *allocator);
+
+/**
+*  @brief
+*    Call a function anonymously by value map (@keys -> @values) and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] keys
+*    Array of values representing argument keys
+*
+*  @param[in] values
+*    Array of values representing argument values data
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallfmv(void *func, void *keys[], void *values[]);
+
+/**
+*  @brief
+*    Call a function anonymously by function @func and serial @buffer of size @size
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] buffer
+*    String representing a map to be deserialized into arguments of the function
+*
+*  @param[in] size
+*    Size of string @buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the value
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallfms(void *func, const char *buffer, size_t size, void *allocator);
+
+/**
+*  @brief
+*    Register a function by name @name and arguments @va_args
+*
+*  @param[in] name
+*    Name of the function (if it is NULL, function is not registered into host scope)
+*
+*  @param[in] invoke
+*    Pointer to function invoke interface (argc, argv, data)
+*
+*  @param[out] func
+*    Will set the pointer to the function if the parameter is not null
+*
+*  @param[in] return_type
+*    Type of return value
+*
+*  @param[in] size
+*    Number of function arguments
+*
+*  @param[in] va_args
+*    Varidic function parameter types
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API int metacall_register(const char *name, void *(*invoke)(size_t, void *[], void *), void **func, enum metacall_value_id return_type, size_t size, ...);
+
+/**
+ *  @brief
+ *    Register a function by name @name and arguments @types
+ *
+ *  @param[in] name
+ *    Name of the function (if it is NULL, function is not registered into host scope)
+ *
+ *  @param[in] invoke
+ *    Pointer to function invoke interface (argc, argv, data)
+ *
+ *  @param[out] func
+ *    Will set the pointer to the function if the parameter is not null
+ *
+ *  @param[in] return_type
+ *    Type of return value
+ *
+ *  @param[in] size
+ *    Number of function arguments
+ *
+ *  @param[in] types
+ *    List of parameter types
+ *
+ *  @return
+ *    Pointer to value containing the result of the call
+ */
+METACALL_API int metacall_registerv(const char *name, void *(*invoke)(size_t, void *[], void *), void **func, enum metacall_value_id return_type, size_t size, enum metacall_value_id types[]);
+
+/**
+*  @brief
+*    Obtain the loader instance by @tag
+*
+*  @param[in] tag
+*    Tag in which the loader is identified, normally it is the extension of the script
+*
+*  @return
+*    Pointer the loader by @tag
+*/
+METACALL_API void *metacall_loader(const char *tag);
+
+/**
+*  @brief
+*    Register a function by name @name and arguments @types
+*
+*  @param[in] loader
+*    Opaque pointer to the loader in which you want to register the function (this allows to register the function into a different loader than the host)
+*
+*  @param[in] handle
+*    Opaque pointer to the handle in which you want to register the function (if it is NULL, it will be defined on the global scope of the loader)
+*
+*  @param[in] name
+*    Name of the function (if it is NULL, function is not registered into host scope)
+*
+*  @param[in] invoke
+*    Pointer to function invoke interface (argc, argv, data)
+*
+*  @param[in] return_type
+*    Type of return value
+*
+*  @param[in] size
+*    Number of function arguments
+*
+*  @param[in] types
+*    List of parameter types
+*
+*  @return
+*    Zero if the function was registered properly, distinct from zero otherwise
+*/
+METACALL_API int metacall_register_loaderv(void *loader, void *handle, const char *name, void *(*invoke)(size_t, void *[], void *), enum metacall_value_id return_type, size_t size, enum metacall_value_id types[]);
+
+/**
+*  @brief
+*    Executes an asynchronous call to the function and registers a callback to be executed when a future is resolved (it does block)
+*
+*  @param[in] name
+*    The name of the function to be called asynchronously
+*
+*  @param[in] args
+*    Array of pointers to the values to be passed to the function
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacall_await(const char *name, void *args[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Awaits for a promise and registers a callback to be executed when a future is resolved
+*
+*  @param[in] f
+*    The pointer to the future
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacall_await_future(void *f, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Executes an asynchronous call to the function and registers a callback to be executed when a future is resolved (it does block)
+*
+*  @param[in] name
+*    The name of the function to be called asynchronously
+*
+*  @param[in] args
+*    Array of pointers to the values to be passed to the function
+*
+*  @param[in] size
+*    Number of elements of the array @args
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacall_await_s(const char *name, void *args[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by value array @args and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] args
+*    Array of pointers to values
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfv_await(void *func, void *args[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by value array @args and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] args
+*    Array of pointers to values
+*
+*  @param[in] size
+*    Number of elements of the array @args
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfv_await_s(void *func, void *args[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by value array @args and function @func (offered without function pointers for languages without support to function pointers)
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] args
+*    Array of pointers to values
+*
+*  @param[in] size
+*    Number of elements of the array @args
+*
+*  @param[in] cb
+*    Pointer to struct containing the function pointers to reject and resolve that will be executed when task completion or error
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfv_await_struct_s(void *func, void *args[], size_t size, metacall_await_callbacks cb, void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by value map (@keys -> @values) and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] keys
+*    Array of values representing argument keys
+*
+*  @param[in] values
+*    Array of values representing argument values data
+*
+*  @param[in] size
+*    Number of elements of the arrays @keys and @values
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfmv_await(void *func, void *keys[], void *values[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by value map (@keys -> @values) and function @func
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] keys
+*    Array of values representing argument keys
+*
+*  @param[in] values
+*    Array of values representing argument values data
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfmv_await_s(void *func, void *keys[], void *values[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by function @func and serial @buffer of size @size
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] buffer
+*    String representing an array to be deserialized into arguments of the function
+*
+*  @param[in] size
+*    Size of string @buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the value
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfs_await(void *func, const char *buffer, size_t size, void *allocator, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Call an asynchronous function anonymously by function @func and serial @buffer of size @size
+*
+*  @param[in] func
+*    Reference to function to be called
+*
+*  @param[in] buffer
+*    String representing a map to be deserialized into arguments of the function
+*
+*  @param[in] size
+*    Size of string @buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the value
+*
+*  @param[in] resolve_callback
+*    Pointer to function that will be executed when task completion
+*      @param[in] void *
+*        Value representing the result of the future resolution
+*      @param[in] void *
+*        A reference to @data that will be used as a closure for the chain
+*      @return
+*        Value containing the result of the operation,
+*        it will be wrapped into a future later on to be returned by the function
+*
+*  @param[in] reject_callback
+*    Pointer to function that will be executed when task error (signature is identical as resolve_callback)
+*
+*  @param[in] data
+*    Pointer to a context that will act as a closure for the chain
+*
+*  @return
+*    Pointer to value containing the result of the call returned by @resolve_callback or @reject_callback wrapped in a future
+*/
+METACALL_API void *metacallfms_await(void *func, const char *buffer, size_t size, void *allocator, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data);
+
+/**
+*  @brief
+*    Get the class by @name
+*
+*  @param[in] name
+*    Name of the class
+*
+*  @return
+*    Class reference, null if the class does not exist
+*/
+METACALL_API void *metacall_class(const char *name);
+
+/**
+*  @brief
+*    Call a class method anonymously by value array @args (this procedure assumes there's no overloaded methods and does type conversion on values)
+*
+*  @param[in] cls
+*    Pointer to the class
+*
+*  @param[in] name
+*    Name of the method
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of args array
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallv_class(void *cls, const char *name, void *args[], size_t size);
+
+/**
+*  @brief
+*    Call a class method anonymously by value array @args and return value type @ret (helps to resolve overloading methods)
+*
+*  @param[in] cls
+*    Pointer to the class
+*
+*  @param[in] name
+*    Name of the method
+*
+*  @param[in] ret
+*    Type of the return value of the method
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of args array
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallt_class(void *cls, const char *name, const enum metacall_value_id ret, void *args[], size_t size);
+
+/**
+*  @brief
+*    Create a new object instance from @cls by value array @args
+*
+*  @param[in] cls
+*    Pointer to the class
+*
+*  @param[in] name
+*    Name of the new object
+*
+*  @param[in] args
+*    Array of pointers constructor parameters
+*
+*  @param[in] size
+*    Number of elements of constructor parameters
+*
+*  @return
+*    Pointer to the new object value instance
+*/
+METACALL_API void *metacall_class_new(void *cls, const char *name, void *args[], size_t size);
+
+/**
+*  @brief
+*    Get an attribute from @cls by @key name
+*
+*  @param[in] cls
+*    Pointer to the class
+*
+*  @param[in] key
+*    Name of the attribute to get
+*
+*  @return
+*    Pointer to the class attribute value or NULL if an error occurred
+*/
+METACALL_API void *metacall_class_static_get(void *cls, const char *key);
+
+/**
+*  @brief
+*    Set an attribute to @cls by @key name
+*
+*  @param[in] cls
+*    Pointer to the class
+*
+*  @param[in] key
+*    Name of the attribute to set
+*
+*  @param[in] value
+*    Value to set
+*
+*  @return
+*    Non-zero integer if an error ocurred
+*/
+METACALL_API int metacall_class_static_set(void *cls, const char *key, void *v);
+
+/**
+*  @brief
+*    Call an object method anonymously by value array @args
+*
+*  @param[in] obj
+*    Pointer to the object
+*
+*  @param[in] name
+*    Name of the method
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of args array
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallv_object(void *obj, const char *name, void *args[], size_t size);
+
+/**
+*  @brief
+*    Call a object method anonymously by value array @args and return value type @ret (helps to resolve overloading methods)
+*
+*  @param[in] obj
+*    Pointer to the object
+*
+*  @param[in] name
+*    Name of the method
+*
+*  @param[in] ret
+*    Type of the return value of the method
+*
+*  @param[in] args
+*    Array of pointers to data
+*
+*  @param[in] size
+*    Number of elements of args array
+*
+*  @return
+*    Pointer to value containing the result of the call
+*/
+METACALL_API void *metacallt_object(void *obj, const char *name, const enum metacall_value_id ret, void *args[], size_t size);
+
+/**
+*  @brief
+*    Get an attribute from @obj by @key name
+*
+*  @param[in] obj
+*    Pointer to the object
+*
+*  @param[in] key
+*    Name of the attribute to get
+*
+*  @return
+*    Pointer to the object attribute value or NULL if an error occurred
+*/
+METACALL_API void *metacall_object_get(void *obj, const char *key);
+
+/**
+*  @brief
+*    Set an attribute to @obj by @key name
+*
+*  @param[in] obj
+*    Pointer to the object
+*
+*  @param[in] key
+*    Name of the attribute to set
+*
+*  @param[in] value
+*    Value to set
+*
+*  @return
+*    Non-zero integer if an error ocurred
+*/
+METACALL_API int metacall_object_set(void *obj, const char *key, void *v);
+
+/**
+*  @brief
+*    Get the value contained by throwable object @th
+*
+*  @param[in] th
+*    Pointer to the throwable object
+*
+*  @return
+*    Pointer to the value inside of the throwable or NULL in case of error
+*/
+METACALL_API void *metacall_throwable_value(void *th);
+
+/**
+*  @brief
+*    Provide information about all loaded objects
+*
+*  @param[out] size
+*    Size in bytes of return buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the string
+*
+*  @return
+*    String containing introspection information
+*/
+METACALL_API char *metacall_inspect(size_t *size, void *allocator);
+
+/**
+*  @brief
+*    Provide information about all loaded objects as a value
+*
+*  @return
+*    Value containing introspection information
+*/
+METACALL_API void *metacall_inspect_value(void);
+
+/**
+*  @brief
+*    Convert the value @v to serialized string
+*
+*  @param[in] name
+*    Name of the serial to be used
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[out] size
+*    Size of new allocated string
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the string
+*
+*  @return
+*    New allocated string containing stringified value
+*/
+METACALL_API char *metacall_serialize(const char *name, void *v, size_t *size, void *allocator);
+
+/**
+*  @brief
+*    Convert the string @buffer to value
+*
+*  @param[in] name
+*    Name of the serial to be used
+*
+*  @param[in] buffer
+*    String to be deserialized
+*
+*  @param[in] size
+*    Size of string @buffer
+*
+*  @param[in] allocator
+*    Pointer to allocator will allocate the value
+*
+*  @return
+*    New allocated value representing the string (must be freed)
+*/
+METACALL_API void *metacall_deserialize(const char *name, const char *buffer, size_t size, void *allocator);
+
+/**
+*  @brief
+*    Clear handle from memory and unload related resources
+*
+*  @param[in] handle
+*    Reference to the handle to be unloaded
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_clear(void *handle);
+
+/**
+*  @brief
+*    Get the plugin extension handle to be used for loading plugins
+*
+*  @return
+*    Pointer to the extension handle, or null if it failed to load
+*/
+METACALL_API void *metacall_plugin_extension(void);
+
+/**
+*  @brief
+*    Get the handle containing all the functionality of the plugins from core
+*
+*  @return
+*    Pointer to the core plugin handle, or null if it failed to load
+*/
+METACALL_API void *metacall_plugin_core(void);
+
+/**
+*  @brief
+*    Get the plugin extension path to be used for accessing the plugins folder
+*
+*  @return
+*    String containing the core plugin path, or null if it failed to load the plugin extension
+*/
+METACALL_API const char *metacall_plugin_path(void);
+
+/**
+*  @brief
+*    Destroy MetaCall library
+*/
+METACALL_API void metacall_destroy(void);
+
+/**
+*  @brief
+*    Provide the module version struct
+*
+*  @return
+*    Static struct containing unpacked version
+*/
+METACALL_API const struct metacall_version_type *metacall_version(void);
+
+/**
+*  @brief
+*    Provide the module version hexadecimal value
+*    with format 0xMMIIPPPP where M is @major,
+*    I is @minor and P is @patch
+*
+*  @param[in] major
+*    Unsigned integer representing major version
+*
+*  @param[in] minor
+*    Unsigned integer representing minor version
+*
+*  @param[in] patch
+*    Unsigned integer representing patch version
+*
+*  @return
+*    Hexadecimal integer containing packed version
+*/
+METACALL_API uint32_t metacall_version_hex_make(unsigned int major, unsigned int minor, unsigned int patch);
+
+/**
+*  @brief
+*    Provide the module version hexadecimal value
+*    with format 0xMMIIPPPP where M is major,
+*    I is minor and P is patch
+*
+*  @return
+*    Hexadecimal integer containing packed version
+*/
+METACALL_API uint32_t metacall_version_hex(void);
+
+/**
+*  @brief
+*    Provide the module version string
+*
+*  @return
+*    Static string containing module version
+*/
+METACALL_API const char *metacall_version_str(void);
+
+/**
+*  @brief
+*    Provide the module version revision string
+*
+*  @return
+*    Static string containing module version revision
+*/
+METACALL_API const char *metacall_version_revision(void);
+
+/**
+*  @brief
+*    Provide the module version name
+*
+*  @return
+*    Static string containing module version name
+*/
+METACALL_API const char *metacall_version_name(void);
+
+/**
+*  @brief
+*    Provide the module information
+*
+*  @return
+*    Static string containing module information
+*/
+METACALL_API const char *metacall_print_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_H */

--- a/source/metacall/include/metacall/metacall_allocator.h
+++ b/source/metacall/include/metacall/metacall_allocator.h
@@ -1,0 +1,134 @@
+
+
+#ifndef METACALL_ALLOCATOR_H
+#define METACALL_ALLOCATOR_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Headers -- */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/* -- Enumerations -- */
+
+enum metacall_allocator_id
+{
+	METACALL_ALLOCATOR_STD,
+	METACALL_ALLOCATOR_NGINX
+};
+
+/* -- Forward Declarations -- */
+
+struct ngx_pool_s;
+
+/* -- Type Definitions -- */
+
+typedef struct metacall_allocator_std_type *metacall_allocator_std;
+
+typedef struct ngx_pool_s ngx_pool_t;
+
+typedef struct metacall_allocator_nginx_type *metacall_allocator_nginx;
+
+/* -- Member Data -- */
+
+struct metacall_allocator_std_type
+{
+	void *(*malloc)(size_t);
+	void *(*realloc)(void *, size_t);
+	void (*free)(void *);
+};
+
+struct metacall_allocator_nginx_type
+{
+	ngx_pool_t *pool;
+	void *(*palloc)(ngx_pool_t *, size_t);
+	void *(*pcopy)(void *, const void *, size_t);
+	intptr_t (*pfree)(ngx_pool_t *, void *);
+};
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Create an allocator instance
+*
+*  @param[in] allocator_id
+*    Type of allocator to be created
+*
+*  @param[in] ctx
+*    Context of the allocator
+*
+*  @return
+*    Pointer to allocator if success, null otherwise
+*/
+METACALL_API void *metacall_allocator_create(enum metacall_allocator_id allocator_id, void *ctx);
+
+/**
+*  @brief
+*    Reserve memory from an allocator instance
+*
+*  @param[in] allocator
+*    Pointer to allocator instance
+*
+*  @param[in] size
+*    Size in bytes to be allocated
+*
+*  @return
+*    Pointer to allocated data on success, null otherwise
+*/
+METACALL_API void *metacall_allocator_alloc(void *allocator, size_t size);
+
+/**
+*  @brief
+*    Reallocate memory from an allocator instance
+*
+*  @param[in] allocator
+*    Pointer to allocator instance
+*
+*  @param[in] data
+*    Original pointer to data
+*
+*  @param[in] size
+*    Original size in bytes
+*
+*  @param[in] new_size
+*    New size in bytes to be reallocated
+*
+*  @return
+*    Pointer to new reallocated data on success, null otherwise
+*/
+METACALL_API void *metacall_allocator_realloc(void *allocator, void *data, size_t size, size_t new_size);
+
+/**
+*  @brief
+*    Free memory from an allocator instance
+*
+*  @param[in] allocator
+*    Pointer to allocator instance
+*
+*  @param[in] data
+*    Pointer to data to be freed
+*/
+METACALL_API void metacall_allocator_free(void *allocator, void *data);
+
+/**
+*  @brief
+*    Destroy an allocator instance
+*
+*  @param[in] allocator
+*    Pointer to allocator instance
+*/
+METACALL_API void metacall_allocator_destroy(void *allocator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_ALLOCATOR_H */

--- a/source/metacall/include/metacall/metacall_error.h
+++ b/source/metacall/include/metacall/metacall_error.h
@@ -1,0 +1,71 @@
+
+
+#ifndef METACALL_ERROR_H
+#define METACALL_ERROR_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Headers -- */
+
+#include <stdint.h>
+
+/* -- Member Data -- */
+
+struct metacall_exception_type
+{
+	const char *message;
+	const char *label;
+	int64_t code;
+	const char *stacktrace;
+};
+
+/* -- Type Definitions -- */
+
+typedef struct metacall_exception_type *metacall_exception;
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Retrieve the exception from a value, it can be either a throwable value with an exception inside or an exception itself
+*
+*  @param[in] v
+*    Value that represents the exception to be retrieved
+*
+*  @param[out] ex
+*    Exception that will be used as out parameter, the lifetime of the struct fields is attached to @v
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_error_from_value(void *v, metacall_exception ex);
+
+/**
+*  @brief
+*    Retrieve last error that has happened after a call to any API from MetaCall
+*
+*  @param[out] ex
+*    Exception that will be used as out parameter, the lifetime of the struct fields is attached to the internal MetaCall exception
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_error_last(metacall_exception ex);
+
+/**
+*  @brief
+*    Clear last error that has happened after a call to any API from MetaCall
+*/
+METACALL_API void metacall_error_clear(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_ERROR_H */

--- a/source/metacall/include/metacall/metacall_fork.h
+++ b/source/metacall/include/metacall/metacall_fork.h
@@ -1,0 +1,80 @@
+
+
+#ifndef METACALL_FORK_H
+#define METACALL_FORK_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(WIN32) || defined(_WIN32) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	defined(__MINGW32__) || defined(__MINGW64__)
+
+	/* -- Headers -- */
+
+	#include <process.h>
+
+/* -- Type Definitions -- */
+
+typedef int metacall_pid;
+
+#elif defined(unix) || defined(__unix__) || defined(__unix) || \
+	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	(defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
+
+	/* -- Headers -- */
+
+	#include <sys/types.h>
+	#include <unistd.h>
+
+/* -- Type Definitions -- */
+
+typedef pid_t metacall_pid;
+
+#else
+	#error "Unknown metacall fork safety platform"
+#endif
+
+typedef int (*metacall_pre_fork_callback_ptr)(void *);
+typedef int (*metacall_post_fork_callback_ptr)(metacall_pid, void *);
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Initialize fork detours and allocate shared memory
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_fork_initialize(void);
+
+/**
+*  @brief
+*    Set fork hook callback
+*
+*  @param[in] pre_callback
+*    Callback to be called before fork detour is executed
+*
+*  @param[in] post_callback
+*    Callback to be called after fork detour is executed
+*/
+METACALL_API void metacall_fork(metacall_pre_fork_callback_ptr pre_callback, metacall_post_fork_callback_ptr post_callback);
+
+/**
+*  @brief
+*    Unregister fork detours and destroy shared memory
+*/
+METACALL_API void metacall_fork_destroy(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_FORK_H */

--- a/source/metacall/include/metacall/metacall_link.h
+++ b/source/metacall/include/metacall/metacall_link.h
@@ -1,0 +1,106 @@
+
+#ifndef METACALL_LINK_H
+#define METACALL_LINK_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Initialize link detours and allocate shared memory
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_link_initialize(void);
+
+/**
+*  @brief
+*    Register a function pointer in order to allow function
+*    interposition when loading a library, if you register a
+*    function @symbol called 'foo', when you try to dlsym (or the equivalent
+*    on every platform), you will get the pointer to @fn, even if
+*    the symbol does not exist in the library, it will work.
+*    Function interposition is required in order to hook into runtimes
+*    and dynamically interpose our functions.
+*
+*  @param[in] tag
+*    Name of the loader which the @library belongs to
+*
+*  @param[in] library
+*    Name of the library that is going to be hooked
+*
+*  @param[in] symbol
+*    Name of the function to be interposed
+*
+*  @param[in] fn
+*    Function pointer that will be returned by dlsym (or equivalent) when accessing to @symbol
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_link_register(const char *tag, const char *library, const char *symbol, void (*fn)(void));
+
+/**
+*  @brief
+*    Register a function pointer in order to allow function
+*    interposition when loading a library, if you register a
+*    function @symbol called 'foo', when you try to dlsym (or the equivalent
+*    on every platform), you will get the pointer to @fn, even if
+*    the symbol does not exist in the library, it will work.
+*    Function interposition is required in order to hook into runtimes
+*    and dynamically interpose our functions.
+*
+*  @param[in] loader
+*    Pointer to the loader which the @library belongs to
+*
+*  @param[in] library
+*    Name of the library that is going to be hooked
+*
+*  @param[in] symbol
+*    Name of the function to be interposed
+*
+*  @param[in] fn
+*    Function pointer that will be returned by dlsym (or equivalent) when accessing to @symbol
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_link_register_loader(void *loader, const char *library, const char *symbol, void (*fn)(void));
+
+/**
+*  @brief
+*    Remove the hook previously registered
+*
+*  @param[in] tag
+*    Name of the loader which the @library belongs to
+*
+*  @param[in] library
+*    Name of the library that is going to be hooked
+*
+*  @param[in] symbol
+*    Name of the function to be interposed
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_link_unregister(const char *tag, const char *library, const char *symbol);
+
+/**
+*  @brief
+*    Unregister link detours and destroy shared memory
+*/
+METACALL_API void metacall_link_destroy(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_LINK_H */

--- a/source/metacall/include/metacall/metacall_log.h
+++ b/source/metacall/include/metacall/metacall_log.h
@@ -1,0 +1,131 @@
+
+
+#ifndef METACALL_LOG_H
+#define METACALL_LOG_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Headers -- */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* -- Enumerations -- */
+
+enum metacall_log_id
+{
+	METACALL_LOG_STDIO,
+	METACALL_LOG_FILE,
+	METACALL_LOG_SOCKET,
+	METACALL_LOG_SYSLOG,
+	METACALL_LOG_NGINX,
+	METACALL_LOG_CUSTOM
+};
+
+/* -- Forward Declarations -- */
+
+struct metacall_log_stdio_type;
+
+struct metacall_log_file_type;
+
+struct metacall_log_socket_type;
+
+struct metacall_log_syslog_type;
+
+struct metacall_log_nginx_type;
+
+struct metacall_log_custom_va_list_type;
+
+struct metacall_log_custom_type;
+
+/* -- Type Definitions -- */
+
+typedef struct metacall_log_stdio_type *metacall_log_stdio;
+
+typedef struct metacall_log_file_type *metacall_log_file;
+
+typedef struct metacall_log_socket_type *metacall_log_socket;
+
+typedef struct metacall_log_syslog_type *metacall_log_syslog;
+
+typedef struct metacall_log_nginx_type *metacall_log_nginx;
+
+typedef struct metacall_log_custom_va_list_type *metacall_log_custom_va_list;
+
+typedef struct metacall_log_custom_type *metacall_log_custom;
+
+/* -- Member Data -- */
+
+struct metacall_log_stdio_type
+{
+	FILE *stream;
+};
+
+struct metacall_log_file_type
+{
+	const char *file_name;
+	const char *mode;
+};
+
+struct metacall_log_socket_type
+{
+	const char *ip;
+	uint16_t port;
+};
+
+struct metacall_log_syslog_type
+{
+	const char *name;
+};
+
+struct metacall_log_nginx_type
+{
+	void *log;
+	void (*log_error)(void);
+	uint16_t log_level;
+};
+
+struct metacall_log_custom_va_list_type
+{
+	va_list va;
+};
+
+struct metacall_log_custom_type
+{
+	void *context;
+	size_t (*format_size)(void *, const char *, uint64_t, size_t, const char *, const char *, const char *, const char *, metacall_log_custom_va_list);
+	size_t (*format_serialize)(void *, void *, const size_t, const char *, uint64_t, size_t, const char *, const char *, const char *, const char *, metacall_log_custom_va_list);
+	size_t (*format_deserialize)(void *, const void *, const size_t, const char *, uint64_t, size_t, const char *, const char *, const char *, const char *, metacall_log_custom_va_list);
+	int (*stream_write)(void *, const char *, const size_t);
+	int (*stream_flush)(void *);
+};
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Create a log instance
+*
+*  @param[in] log_id
+*    Type of log to be created
+*
+*  @param[in] ctx
+*    Context of the log (a pointer to metacall_log_{stdio, file, socket, syslog, nginx, custom}_type)
+*
+*  @return
+*    Zero if success, different from zero otherwise
+*/
+METACALL_API int metacall_log(enum metacall_log_id log_id, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_LOG_H */

--- a/source/metacall/include/metacall/metacall_value.h
+++ b/source/metacall/include/metacall/metacall_value.h
@@ -1,0 +1,1213 @@
+
+
+#ifndef METACALL_VALUE_H
+#define METACALL_VALUE_H 1
+
+/* -- Headers -- */
+
+#include <metacall/metacall_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Headers -- */
+
+#include <stdlib.h>
+
+/* -- Definitions -- */
+
+#ifndef boolean
+	#define boolean unsigned char
+#endif
+
+/* -- Enumerations -- */
+
+enum metacall_value_id
+{
+	METACALL_BOOL = 0,
+	METACALL_CHAR = 1,
+	METACALL_SHORT = 2,
+	METACALL_INT = 3,
+	METACALL_LONG = 4,
+	METACALL_FLOAT = 5,
+	METACALL_DOUBLE = 6,
+	METACALL_STRING = 7,
+	METACALL_BUFFER = 8,
+	METACALL_ARRAY = 9,
+	METACALL_MAP = 10,
+	METACALL_PTR = 11,
+	METACALL_FUTURE = 12,
+	METACALL_FUNCTION = 13,
+	METACALL_NULL = 14,
+	METACALL_CLASS = 15,
+	METACALL_OBJECT = 16,
+	METACALL_EXCEPTION = 17,
+	METACALL_THROWABLE = 18,
+
+	METACALL_SIZE,
+	METACALL_INVALID
+};
+
+/* -- Methods -- */
+
+/**
+*  @brief
+*    Create a value from boolean @b
+*
+*  @param[in] b
+*    Boolean will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_bool(boolean b);
+
+/**
+*  @brief
+*    Create a value from char @c
+*
+*  @param[in] c
+*    Character will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_char(char c);
+
+/**
+*  @brief
+*    Create a value from short @s
+*
+*  @param[in] s
+*    Short will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_short(short s);
+
+/**
+*  @brief
+*    Create a value from integer @i
+*
+*  @param[in] i
+*    Integer will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_int(int i);
+
+/**
+*  @brief
+*    Create a value from long @l
+*
+*  @param[in] l
+*    Long integer will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_long(long l);
+
+/**
+*  @brief
+*    Create a value from single precision floating point number @f
+*
+*  @param[in] f
+*    Float will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_float(float f);
+
+/**
+*  @brief
+*    Create a value from double precision floating point number @d
+*
+*  @param[in] d
+*    Double will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_double(double d);
+
+/**
+*  @brief
+*    Create a value from a C string @str
+*
+*  @param[in] str
+*    Constant string will be copied into value (needs to be null terminated)
+*
+*  @param[in] length
+*    Length of the constant string
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_string(const char *str, size_t length);
+
+/**
+*  @brief
+*    Create a value buffer from array @buffer
+*
+*  @param[in] buffer
+*    Constant memory block will be copied into value array
+*
+*  @param[in] size
+*    Size in bytes of data contained in the array
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_buffer(const void *buffer, size_t size);
+
+/**
+*  @brief
+*    Create a value array from array of values @values
+*
+*  @param[in] values
+*    Constant array of values will be copied into value list
+*
+*  @param[in] size
+*    Number of elements contained in the array
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_array(const void *values[], size_t size);
+
+/**
+*  @brief
+*    Create a value map from array of tuples @map
+*
+*  @param[in] tuples
+*    Constant array of tuples will be copied into value map
+*
+*  @param[in] size
+*    Number of elements contained in the map
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_map(const void *tuples[], size_t size);
+
+/**
+*  @brief
+*    Create a value from pointer @ptr
+*
+*  @param[in] ptr
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_ptr(const void *ptr);
+
+/**
+*  @brief
+*    Create a value from future @f
+*
+*  @param[in] f
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_future(void *f);
+
+/**
+*  @brief
+*    Create a value from function @f
+*
+*  @param[in] f
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_function(void *f);
+
+/**
+*  @brief
+*    Create a value from function @f binding a closure @c to it
+*
+*  @param[in] f
+*    Pointer to constant data will be copied into value
+*
+*  @param[in] c
+*    Pointer to closure that will be binded into function @f
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_function_closure(void *f, void *c);
+
+/**
+*  @brief
+*    Create a value of type null
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_null(void);
+
+/**
+*  @brief
+*    Create a value from class @c
+*
+*  @param[in] c
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_class(void *c);
+
+/**
+*  @brief
+*    Create a value from object @o
+*
+*  @param[in] o
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_object(void *o);
+
+/**
+*  @brief
+*    Create a value from exception @ex
+*
+*  @param[in] ex
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_exception(void *ex);
+
+/**
+*  @brief
+*    Create a value from throwable @th
+*
+*  @param[in] th
+*    Pointer to constant data will be copied into value
+*
+*  @return
+*    Pointer to value if success, null otherwhise
+*/
+METACALL_API void *metacall_value_create_throwable(void *th);
+
+/**
+*  @brief
+*    Returns the size of the value
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Size in bytes of the value
+*/
+METACALL_API size_t metacall_value_size(void *v);
+
+/**
+*  @brief
+*    Returns the amount of values this value contains
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Number of values @v represents
+*/
+METACALL_API size_t metacall_value_count(void *v);
+
+/**
+*  @brief
+*    Provide type id of value
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Return type id assigned to value
+*/
+METACALL_API enum metacall_value_id metacall_value_id(void *v);
+
+/**
+*  @brief
+*    Provide type id in a readable form (as string) of a type id
+*
+*  @param[in] id
+*    Value type identifier
+*
+*  @return
+*    Return string related to the type id
+*/
+METACALL_API const char *metacall_value_id_name(enum metacall_value_id id);
+
+/**
+*  @brief
+*    Provide type id in a readable form (as string) of value
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Return string related to the type id assigned to value
+*/
+METACALL_API const char *metacall_value_type_name(void *v);
+
+/**
+*  @brief
+*    Deep copies the value @v, the result copy resets
+*    the reference counter and ownership, including the finalizer
+*
+*  @param[in] v
+*    Reference to the value to be copied
+*
+*  @return
+*    Copy of the value @v on success, null otherwhise
+*/
+METACALL_API void *metacall_value_copy(void *v);
+
+/**
+*  @brief
+*    Creates a new pointer value, with a reference to the
+*    data contained inside the value @v. For example:
+*
+*    void *v = metacall_value_create_int(20);
+*    void *ptr = metacall_value_reference(v);
+*
+*    In this case, void *ptr is a value equivalent to int*,
+*    and it points directly to the integer contained in void *v.
+*    Note that if we destroy the value @v, the reference will
+*    point to already freed memory, causing use-after-free when used.
+*
+*  @param[in] v
+*    Reference to the value to be referenced
+*
+*  @return
+*    A new value of type pointer, pointing to the @v data
+*/
+METACALL_API void *metacall_value_reference(void *v);
+
+/**
+*  @brief
+*    If you pass a reference previously created (i.e a value of
+*    type pointer, pointing to another value), it returns the
+*    original value. It does not modify the memory of the values
+*    neither allocates anything. If the value @v is pointing to
+*    has been deleted, it will cause an use-after-free. For example:
+*
+*    void *v = metacall_value_create_int(20);
+*    void *ptr = metacall_value_reference(v);
+*    void *w = metacall_value_dereference(ptr);
+*    assert(v == w); // Both are the same value
+*
+*  @param[in] v
+*    Reference to the value to be dereferenced
+*
+*  @return
+*    The value containing the data which ptr is pointing to
+*/
+METACALL_API void *metacall_value_dereference(void *v);
+
+/**
+*  @brief
+*    Copies the ownership from @src to @dst, including the finalizer,
+*    and resets the owner and finalizer of @src
+*
+*  @param[in] src
+*    Source value which will lose the ownership
+*
+*  @param[in] dst
+*    Destination value which will recieve the ownership
+*/
+METACALL_API void metacall_value_move(void *src, void *dest);
+
+/**
+*  @brief
+*    Convert value @v to boolean
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to boolean
+*/
+METACALL_API boolean metacall_value_to_bool(void *v);
+
+/**
+*  @brief
+*    Convert value @v to char
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to char
+*/
+METACALL_API char metacall_value_to_char(void *v);
+
+/**
+*  @brief
+*    Convert value @v to short
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to short
+*/
+METACALL_API short metacall_value_to_short(void *v);
+
+/**
+*  @brief
+*    Convert value @v to integer
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to integer
+*/
+METACALL_API int metacall_value_to_int(void *v);
+
+/**
+*  @brief
+*    Convert value @v to long integer
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to long integer
+*/
+METACALL_API long metacall_value_to_long(void *v);
+
+/**
+*  @brief
+*    Convert value @v to single precision floating point
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to float
+*/
+METACALL_API float metacall_value_to_float(void *v);
+
+/**
+*  @brief
+*    Convert value @v to double precision floating point
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to dobule
+*/
+METACALL_API double metacall_value_to_double(void *v);
+
+/**
+*  @brief
+*    Convert value @v to string
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to C string (null terminated)
+*/
+METACALL_API char *metacall_value_to_string(void *v);
+
+/**
+*  @brief
+*    Convert value @v to buffer
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to memory block
+*/
+METACALL_API void *metacall_value_to_buffer(void *v);
+
+/**
+*  @brief
+*    Convert value @v to array of values
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to array of values
+*/
+METACALL_API void **metacall_value_to_array(void *v);
+
+/**
+*  @brief
+*    Convert value @v to map
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to map (array of tuples (array of values))
+*/
+METACALL_API void **metacall_value_to_map(void *v);
+
+/**
+*  @brief
+*    Convert value @v to pointer
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to pointer
+*/
+METACALL_API void *metacall_value_to_ptr(void *v);
+
+/**
+*  @brief
+*    Convert value @v to future
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to future
+*/
+METACALL_API void *metacall_value_to_future(void *v);
+
+/**
+*  @brief
+*    Convert value @v to function
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to function
+*/
+METACALL_API void *metacall_value_to_function(void *v);
+
+/**
+*  @brief
+*    Convert value @v to null
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to null
+*/
+METACALL_API void *metacall_value_to_null(void *v);
+
+/**
+*  @brief
+*    Convert value @v to class
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to class
+*/
+METACALL_API void *metacall_value_to_class(void *v);
+
+/**
+*  @brief
+*    Convert value @v to object
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to object
+*/
+METACALL_API void *metacall_value_to_object(void *v);
+
+/**
+*  @brief
+*    Convert value @v to exception
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to exception
+*/
+METACALL_API void *metacall_value_to_exception(void *v);
+
+/**
+*  @brief
+*    Convert value @v to throwable
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value converted to throwable
+*/
+METACALL_API void *metacall_value_to_throwable(void *v);
+
+/**
+*  @brief
+*    Assign boolean @b to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] b
+*    Boolean to be assigned to value @v
+*
+*  @return
+*    Value with boolean @b assigned to it
+*/
+METACALL_API void *metacall_value_from_bool(void *v, boolean b);
+
+/**
+*  @brief
+*    Assign character @c to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] c
+*    Character to be assigned to value @v
+*
+*  @return
+*    Value with char @c assigned to it
+*/
+METACALL_API void *metacall_value_from_char(void *v, char c);
+
+/**
+*  @brief
+*    Assign short @s to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] s
+*    Short to be assigned to value @v
+*
+*  @return
+*    Value with short @s assigned to it
+*/
+METACALL_API void *metacall_value_from_short(void *v, short s);
+
+/**
+*  @brief
+*    Assign integer @i to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] i
+*    Integer to be assigned to value @v
+*
+*  @return
+*    Value with integer @i assigned to it
+*/
+METACALL_API void *metacall_value_from_int(void *v, int i);
+
+/**
+*  @brief
+*    Assign long integer @l to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] l
+*    Long integer to be assigned to value @v
+*
+*  @return
+*    Value with long @l assigned to it
+*/
+METACALL_API void *metacall_value_from_long(void *v, long l);
+
+/**
+*  @brief
+*    Assign single precision floating point @f to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] f
+*    Float to be assigned to value @v
+*
+*  @return
+*    Value with float @f assigned to it
+*/
+METACALL_API void *metacall_value_from_float(void *v, float f);
+
+/**
+*  @brief
+*    Assign double precision floating point @d to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] d
+*    Double to be assigned to value @v
+*
+*  @return
+*    Value with double @d assigned to it
+*/
+METACALL_API void *metacall_value_from_double(void *v, double d);
+
+/**
+*  @brief
+*    Assign string @str to value @v, truncates to @v size if it is smaller
+*    than @length + 1. It does not add null terminator if truncated.
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] str
+*    Constant string to be assigned to value @v (it needs to be null terminated)
+*
+*  @param[in] length
+*    Length of the constant string @str
+*
+*  @return
+*    Value with string @str assigned to it
+*/
+METACALL_API void *metacall_value_from_string(void *v, const char *str, size_t length);
+
+/**
+*  @brief
+*    Assign array @buffer to value buffer @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] buffer
+*    Constant array to be assigned to value @v
+*
+*  @param[in] size
+*    Number of elements contained in @buffer
+*
+*  @return
+*    Value with array @buffer assigned to it
+*/
+METACALL_API void *metacall_value_from_buffer(void *v, const void *buffer, size_t size);
+
+/**
+*  @brief
+*    Assign array of values @values to value array @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] values
+*    Constant array of values to be assigned to value array @v
+*
+*  @param[in] size
+*    Number of values contained in constant array @values
+*
+*  @return
+*    Value with array of values @values assigned to it
+*/
+METACALL_API void *metacall_value_from_array(void *v, const void *values[], size_t size);
+
+/**
+*  @brief
+*    Assign array of values @values to value map @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] tuples
+*    Constant array of tuples to be assigned to value map @v
+*
+*  @param[in] size
+*    Number of values contained in constant array @tuples
+*
+*  @return
+*    Value with array of tuples @tuples assigned to it
+*/
+METACALL_API void *metacall_value_from_map(void *v, const void *tuples[], size_t size);
+
+/**
+*  @brief
+*    Assign pointer reference @ptr to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] ptr
+*    Pointer to be assigned to value @v
+*
+*  @return
+*    Value with pointer @ptr assigned to it
+*/
+METACALL_API void *metacall_value_from_ptr(void *v, const void *ptr);
+
+/**
+*  @brief
+*    Assign future @f to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] f
+*    Future to be assigned to value @v
+*
+*  @return
+*    Value with future @f assigned to it
+*/
+METACALL_API void *metacall_value_from_future(void *v, void *f);
+
+/**
+*  @brief
+*    Assign function @f to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] f
+*    Function to be assigned to value @v
+*
+*  @return
+*    Value with function @f assigned to it
+*/
+METACALL_API void *metacall_value_from_function(void *v, void *f);
+
+/**
+*  @brief
+*    Assign null to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @return
+*    Value with null assigned to it
+*/
+METACALL_API void *metacall_value_from_null(void *v);
+
+/**
+*  @brief
+*    Assign class @c to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] c
+*    Class to be assigned to value @v
+*
+*  @return
+*    Value with class @c assigned to it
+*/
+METACALL_API void *metacall_value_from_class(void *v, void *c);
+
+/**
+*  @brief
+*    Assign object @o to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] o
+*    Object to be assigned to value @v
+*
+*  @return
+*    Value with object @o assigned to it
+*/
+METACALL_API void *metacall_value_from_object(void *v, void *o);
+
+/**
+*  @brief
+*    Assign exception @ex to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] ex
+*    Exception to be assigned to value @v
+*
+*  @return
+*    Value with exception @ex assigned to it
+*/
+METACALL_API void *metacall_value_from_exception(void *v, void *ex);
+
+/**
+*  @brief
+*    Assign throwable @th to value @v
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] th
+*    Throwable to be assigned to value @v
+*
+*  @return
+*    Value with throwable @th assigned to it
+*/
+METACALL_API void *metacall_value_from_throwable(void *v, void *th);
+
+/**
+*  @brief
+*    Casts a value to a new type @id
+*
+*  @param[in] v
+*    Reference to the value
+*
+*  @param[in] id
+*    New type id of value to be casted
+*
+*  @return
+*    Casted value or reference to @v if casting is between equivalent types
+*/
+METACALL_API void *metacall_value_cast(void *v, enum metacall_value_id id);
+
+/**
+*  @brief
+*    Convert value @v implicitly to boolean
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to boolean
+*/
+METACALL_API boolean metacall_value_cast_bool(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to char
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to char
+*/
+METACALL_API char metacall_value_cast_char(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to short
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to short
+*/
+METACALL_API short metacall_value_cast_short(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to int
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to int
+*/
+METACALL_API int metacall_value_cast_int(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to long
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to long
+*/
+METACALL_API long metacall_value_cast_long(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to float
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to float
+*/
+METACALL_API float metacall_value_cast_float(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to double
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to double
+*/
+METACALL_API double metacall_value_cast_double(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to string
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to a C string (null terminated)
+*/
+METACALL_API char *metacall_value_cast_string(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to buffer
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to buffer
+*/
+METACALL_API void *metacall_value_cast_buffer(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to array
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to array of values
+*/
+METACALL_API void **metacall_value_cast_array(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to map
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to map
+*/
+METACALL_API void *metacall_value_cast_map(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to ptr
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to ptr
+*/
+METACALL_API void *metacall_value_cast_ptr(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to future
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to future
+*/
+METACALL_API void *metacall_value_cast_future(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to function
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to function
+*/
+METACALL_API void *metacall_value_cast_function(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to null
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to null
+*/
+METACALL_API void *metacall_value_cast_null(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to class
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to class
+*/
+METACALL_API void *metacall_value_cast_class(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to object
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to object
+*/
+METACALL_API void *metacall_value_cast_object(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to exception
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to exception
+*/
+METACALL_API void *metacall_value_cast_exception(void **v);
+
+/**
+*  @brief
+*    Convert value @v implicitly to throwable
+*
+*  @param[in] v
+*    Reference to the reference of the value
+*
+*  @return
+*    Value converted to throwable
+*/
+METACALL_API void *metacall_value_cast_throwable(void **v);
+
+/**
+*  @brief
+*    Destroy a value from scope stack
+*
+*  @param[in] v
+*    Reference to the value
+*/
+METACALL_API void metacall_value_destroy(void *v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* METACALL_VALUE_H */

--- a/source/metacall/metacall_def.h.in
+++ b/source/metacall/metacall_def.h.in
@@ -1,0 +1,7 @@
+#ifndef METACALL_DEF_H
+#define METACALL_DEF_H 1
+
+#cmakedefine METACALL_FORK_SAFE		1
+#cmakedefine METACALL_THREAD_SAFE	1
+
+#endif

--- a/source/metacall/source/metacall.c
+++ b/source/metacall/source/metacall.c
@@ -1,0 +1,2428 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall.h>
+#include <metacall/metacall_loaders.h>
+
+#include <loader/loader.h>
+
+#include <reflect/reflect.h>
+
+#include <configuration/configuration.h>
+
+#include <log/log.h>
+
+#include <serial/serial.h>
+
+#include <detour/detour.h>
+
+#include <environment/environment_variable.h>
+
+#include <portability/portability_atexit.h>
+#include <portability/portability_constructor.h>
+
+#include <stdio.h>
+#include <string.h>
+
+/* -- Definitions -- */
+
+#define METACALL_ARGS_SIZE 0x10
+#define METACALL_SERIAL	   "rapid_json"
+#define METACALL_DETOUR	   "plthook"
+
+/* -- Type Definitions -- */
+
+typedef value (*method_invoke_ptr)(void *, method, void *[], size_t);
+
+/* -- Global Variables -- */
+
+void *metacall_null_args[1] = { NULL };
+
+/* -- Private Variables -- */
+
+static int metacall_initialize_flag = 1;
+static int metacall_log_null_flag = 1;
+static int metacall_config_flags = 0;
+static int metacall_initialize_argc = 0;
+static char **metacall_initialize_argv = NULL;
+static void *plugin_extension_handle = NULL;
+static void *plugin_core_handle = NULL;
+static loader_path plugin_path = { 0 };
+
+/* -- Private Methods -- */
+
+static int metacall_plugin_extension_load(void);
+static void *metacallv_method(void *target, const char *name, method_invoke_ptr call, vector v, void *args[], size_t size);
+static type_id *metacall_type_ids(void *args[], size_t size);
+static void metacall_detour_destructor(void);
+
+/* -- Costructors -- */
+
+portability_constructor(metacall_constructor)
+{
+	if (metacall_initialize_flag == 1)
+	{
+		const char *metacall_host = environment_variable_get("METACALL_HOST", NULL);
+
+		/* Initialize at exit handlers */
+		portability_atexit_initialize();
+
+		/* We are running from a different host, initialize the loader of the host
+		* and redirect it to the existing symbols, also avoiding initialization
+		* and destruction of the runtime as it is being managed externally to MetaCall */
+		if (metacall_host != NULL)
+		{
+			static const char host_str[] = "host";
+
+			struct metacall_initialize_configuration_type config[] = {
+				{ metacall_host, metacall_value_create_map(NULL, 1) },
+				{ NULL, NULL }
+			};
+
+			/* Initialize the loader options with a map defining its options to { "host": true } */
+			void **host_tuple, **options_map = metacall_value_to_map(config[0].options);
+
+			options_map[0] = metacall_value_create_array(NULL, 2);
+
+			host_tuple = metacall_value_to_array(options_map[0]);
+
+			host_tuple[0] = metacall_value_create_string(host_str, sizeof(host_str) - 1);
+			host_tuple[1] = metacall_value_create_bool(1);
+
+			/* Initialize MetaCall with extra options, defining the host properly */
+			if (metacall_initialize_ex(config) != 0)
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "MetaCall host constructor failed to initialize");
+				exit(1);
+			}
+
+			/* Register the destructor on exit */
+			portability_atexit_register(metacall_destroy);
+		}
+	}
+}
+
+/* -- Methods -- */
+
+const char *metacall_serial(void)
+{
+	static const char metacall_serial_str[] = METACALL_SERIAL;
+
+	return metacall_serial_str;
+}
+
+const char *metacall_detour(void)
+{
+	static const char metacall_detour_str[] = METACALL_DETOUR;
+
+	return metacall_detour_str;
+}
+
+void metacall_log_null(void)
+{
+	metacall_log_null_flag = 0;
+}
+
+void metacall_flags(int flags)
+{
+	metacall_config_flags = flags;
+}
+
+int metacall_plugin_extension_load(void)
+{
+	static const char *ext_scripts[] = {
+		"plugin_extension"
+	};
+	static const char plugin_suffix[] = "plugins";
+	const char *library_path = loader_library_path();
+	size_t plugin_path_size;
+	void *args[2];
+	void *ret;
+	int result = 1;
+
+	/* Load the plugin extension */
+	if (metacall_load_from_file("ext", ext_scripts, sizeof(ext_scripts) / sizeof(ext_scripts[0]), &plugin_extension_handle) != 0)
+	{
+		goto plugin_extension_error;
+	}
+
+	/* Get the plugin path */
+	plugin_path_size = portability_path_join(library_path, strnlen(library_path, PORTABILITY_PATH_SIZE) + 1, plugin_suffix, sizeof(plugin_suffix), plugin_path, PORTABILITY_PATH_SIZE);
+
+	/* Load core plugins into plugin extension handle */
+	args[0] = metacall_value_create_string(plugin_path, plugin_path_size - 1);
+	args[1] = metacall_value_create_ptr(&plugin_core_handle);
+	ret = metacallhv_s(plugin_extension_handle, "plugin_load_from_path", args, sizeof(args) / sizeof(args[0]));
+
+	if (ret == NULL)
+	{
+		goto plugin_load_from_path_error;
+	}
+
+	if (metacall_value_id(ret) != METACALL_INT)
+	{
+		goto plugin_load_from_path_type_error;
+	}
+
+	/* Retrieve the result value */
+	result = metacall_value_to_int(ret);
+
+plugin_load_from_path_type_error:
+	metacall_value_destroy(ret);
+plugin_load_from_path_error:
+	metacall_value_destroy(args[0]);
+	metacall_value_destroy(args[1]);
+plugin_extension_error:
+	return result;
+}
+
+void metacall_detour_destructor(void)
+{
+	/* Destroy link */
+	metacall_link_destroy();
+
+	/* Destroy fork */
+#ifdef METACALL_FORK_SAFE
+	if (metacall_config_flags & METACALL_FLAGS_FORK_SAFE)
+	{
+		metacall_fork_destroy();
+	}
+#endif /* METACALL_FORK_SAFE */
+
+	/* Destroy detour */
+	detour_destroy();
+}
+
+int metacall_initialize(void)
+{
+	memory_allocator allocator;
+
+	if (metacall_initialize_flag == 0)
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall already initialized");
+
+		return 0;
+	}
+
+	/* Initialize logs by default to stdout if none has been defined */
+	if (metacall_log_null_flag != 0 && log_size() == 0)
+	{
+		struct metacall_log_stdio_type log_stdio;
+
+		log_stdio.stream = stdout;
+
+		if (metacall_log(METACALL_LOG_STDIO, (void *)&log_stdio) != 0)
+		{
+			return 1;
+		}
+
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall default logger to stdout initialized");
+	}
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "Initializing MetaCall");
+
+	/* Initialize MetaCall version environment variable */
+	if (environment_variable_set_expand(METACALL_VERSION) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "MetaCall environment variables could not be initialized");
+		return 1;
+	}
+
+	/* Initialize detours */
+	{
+		if (detour_initialize() != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour initialization");
+			return 1;
+		}
+
+#ifdef METACALL_FORK_SAFE
+		if (metacall_config_flags & METACALL_FLAGS_FORK_SAFE)
+		{
+			if (metacall_fork_initialize() != 0)
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid MetaCall fork initialization");
+			}
+
+			log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall fork initialized");
+		}
+#endif /* METACALL_FORK_SAFE */
+
+		/* Define destructor for detouring (it must be executed at the end to prevent problems with fork mechanisms) */
+		portability_atexit_register(metacall_detour_destructor);
+	}
+
+	/* Initialize configuration and serializer */
+	allocator = memory_allocator_std(&malloc, &realloc, &free);
+
+	if (configuration_initialize(metacall_serial(), NULL, allocator) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid MetaCall configuration initialization");
+
+		memory_allocator_destroy(allocator);
+
+		return 1;
+	}
+
+	memory_allocator_destroy(allocator);
+
+	/* TODO: Improve log initialization and configuration */
+	{
+		configuration config = configuration_scope(CONFIGURATION_GLOBAL_SCOPE);
+
+		if (config != NULL)
+		{
+			value *level = configuration_value_type(config, "log_level", TYPE_STRING);
+
+			if (level != NULL)
+			{
+				const char *level_str = (const char *)value_to_string(level);
+
+				if (log_level("metacall", level_str, value_type_size(level) - 1) != 0)
+				{
+					log_write("metacall", LOG_LEVEL_ERROR, "Invalid MetaCall configuration log_level, %s is not valid", level_str);
+				}
+				else
+				{
+					log_write("metacall", LOG_LEVEL_DEBUG, "Set MetaCall log level to %s", level_str);
+				}
+			}
+		}
+	}
+
+	/* Initialize loader subsystem */
+	if (loader_initialize() != 0)
+	{
+		configuration_destroy();
+
+		return 1;
+	}
+
+	/* Initialize link */
+	if (metacall_link_initialize() != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid MetaCall link initialization");
+	}
+
+	/* Load core plugins */
+	if (metacall_plugin_extension_load() != 0)
+	{
+		log_write("metacall", LOG_LEVEL_WARNING, "MetaCall Plugin Extension could not be loaded");
+	}
+
+	metacall_initialize_flag = 0;
+
+	return 0;
+}
+
+int metacall_initialize_ex(struct metacall_initialize_configuration_type initialize_config[])
+{
+	size_t index = 0;
+
+	if (metacall_initialize() == 1)
+	{
+		return 1;
+	}
+
+	while (!(initialize_config[index].tag == NULL && initialize_config[index].options == NULL))
+	{
+		if (loader_set_options(initialize_config[index].tag, initialize_config[index].options) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall failed to set options of '%s_loader'", initialize_config[index].tag);
+			return 1;
+		}
+
+		++index;
+	}
+
+	return 0;
+}
+
+void metacall_initialize_args(int argc, char *argv[])
+{
+	metacall_initialize_argc = argc;
+	metacall_initialize_argv = argv;
+}
+
+char **metacall_argv(void)
+{
+	return metacall_initialize_argv;
+}
+
+int metacall_argc(void)
+{
+	return metacall_initialize_argc;
+}
+
+int metacall_is_initialized(const char *tag)
+{
+	if (tag == NULL)
+	{
+		return metacall_initialize_flag;
+	}
+
+	return loader_is_initialized(tag);
+}
+
+size_t metacall_args_size(void)
+{
+	const size_t args_size = METACALL_ARGS_SIZE;
+
+	return args_size;
+}
+
+int metacall_execution_path(const char *tag, const char *path)
+{
+	loader_path path_impl;
+
+	if (tag == NULL || path == NULL)
+	{
+		return 1;
+	}
+
+	strncpy(path_impl, path, LOADER_PATH_SIZE - 1);
+
+	return loader_execution_path(tag, path_impl);
+}
+
+int metacall_execution_path_s(const char *tag, size_t tag_length, const char *path, size_t path_length)
+{
+	loader_path path_impl;
+	loader_tag tag_impl;
+
+	if (tag == NULL || tag_length == 0 || tag_length >= LOADER_TAG_SIZE || path == NULL || path_length == 0 || path_length >= LOADER_PATH_SIZE)
+	{
+		return 1;
+	}
+
+	strncpy(path_impl, path, path_length);
+	strncpy(tag_impl, tag, tag_length);
+
+	path_impl[path_length] = '\0';
+	tag_impl[tag_length] = '\0';
+
+	return loader_execution_path(tag_impl, path_impl);
+}
+
+int metacall_load_from_file(const char *tag, const char *paths[], size_t size, void **handle)
+{
+	loader_path *path_impl;
+	size_t iterator;
+
+	if (size == 0)
+	{
+		return 1;
+	}
+
+	path_impl = (loader_path *)malloc(sizeof(loader_path) * size);
+
+	if (path_impl == NULL)
+	{
+		return 1;
+	}
+
+	for (iterator = 0; iterator < size; ++iterator)
+	{
+		strncpy(path_impl[iterator], paths[iterator], LOADER_PATH_SIZE);
+	}
+
+	int result = loader_load_from_file(tag, (const loader_path *)path_impl, size, handle);
+
+	free(path_impl);
+
+	return result;
+}
+
+int metacall_load_from_memory(const char *tag, const char *buffer, size_t size, void **handle)
+{
+	return loader_load_from_memory(tag, buffer, size, handle);
+}
+
+int metacall_load_from_package(const char *tag, const char *path, void **handle)
+{
+	return loader_load_from_package(tag, path, handle);
+}
+
+int metacall_load_from_configuration(const char *path, void **handle, void *allocator)
+{
+	return loader_load_from_configuration(path, handle, allocator);
+}
+
+void *metacallv(const char *name, void *args[])
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return metacallfv(f, args);
+}
+
+void *metacallv_s(const char *name, void *args[], size_t size)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return metacallfv_s(f, args, size);
+}
+
+void *metacallhv(void *handle, const char *name, void *args[])
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallhv is not valid", handle);
+		return NULL;
+	}
+
+	value f_val = loader_handle_get(handle, name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return metacallfv(f, args);
+}
+
+void *metacallhv_s(void *handle, const char *name, void *args[], size_t size)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallhv_s is not valid", handle);
+		return NULL;
+	}
+
+	value f_val = loader_handle_get(handle, name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return metacallfv_s(f, args, size);
+}
+
+void *metacall(const char *name, ...)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		value ret = NULL;
+
+		signature s = function_signature(f);
+
+		size_t iterator, args_count = signature_count(s);
+
+		va_list va;
+
+		va_start(va, name);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			type t = signature_get_type(s, iterator);
+
+			type_id id = type_index(t);
+
+			if (id == TYPE_BOOL)
+			{
+				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
+			}
+			else if (id == TYPE_CHAR)
+			{
+				args[iterator] = value_create_char((char)va_arg(va, int));
+			}
+			else if (id == TYPE_SHORT)
+			{
+				args[iterator] = value_create_short((short)va_arg(va, int));
+			}
+			else if (id == TYPE_INT)
+			{
+				args[iterator] = value_create_int(va_arg(va, int));
+			}
+			else if (id == TYPE_LONG)
+			{
+				args[iterator] = value_create_long(va_arg(va, long));
+			}
+			else if (id == TYPE_FLOAT)
+			{
+				args[iterator] = value_create_float((float)va_arg(va, double));
+			}
+			else if (id == TYPE_DOUBLE)
+			{
+				args[iterator] = value_create_double(va_arg(va, double));
+			}
+			else if (id == TYPE_STRING)
+			{
+				const char *str = va_arg(va, const char *);
+
+				args[iterator] = value_create_string(str, strlen(str));
+			}
+			else if (id == TYPE_PTR)
+			{
+				args[iterator] = value_create_ptr(va_arg(va, const void *));
+			}
+			else
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Calling metacall with unsupported type '%s', using null type instead", type_id_name(id));
+				args[iterator] = metacall_value_create_null();
+			}
+		}
+
+		va_end(va);
+
+		ret = function_call(f, args, args_count);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			value_type_destroy(args[iterator]);
+		}
+
+		if (ret != NULL)
+		{
+			type t = signature_get_return(s);
+
+			if (t != NULL)
+			{
+				type_id id = type_index(t);
+
+				if (id != value_type_id(ret))
+				{
+					value cast_ret = value_type_cast(ret, id);
+
+					return (cast_ret == NULL) ? ret : cast_ret;
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallt(const char *name, const enum metacall_value_id ids[], ...)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		value ret = NULL;
+
+		signature s = function_signature(f);
+
+		size_t iterator, args_count = signature_count(s);
+
+		va_list va;
+
+		va_start(va, ids);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			type t = signature_get_type(s, iterator);
+
+			type_id id = type_index(t);
+
+			if (t != NULL)
+			{
+				id = type_index(t);
+			}
+			else
+			{
+				id = ids[iterator];
+			}
+
+			if (id == TYPE_BOOL)
+			{
+				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
+			}
+			if (id == TYPE_CHAR)
+			{
+				args[iterator] = value_create_char((char)va_arg(va, int));
+			}
+			else if (id == TYPE_SHORT)
+			{
+				args[iterator] = value_create_short((short)va_arg(va, int));
+			}
+			else if (id == TYPE_INT)
+			{
+				args[iterator] = value_create_int(va_arg(va, int));
+			}
+			else if (id == TYPE_LONG)
+			{
+				args[iterator] = value_create_long(va_arg(va, long));
+			}
+			else if (id == TYPE_FLOAT)
+			{
+				args[iterator] = value_create_float((float)va_arg(va, double));
+			}
+			else if (id == TYPE_DOUBLE)
+			{
+				args[iterator] = value_create_double(va_arg(va, double));
+			}
+			else if (id == TYPE_STRING)
+			{
+				const char *str = va_arg(va, const char *);
+
+				args[iterator] = value_create_string(str, strlen(str));
+			}
+			else if (id == TYPE_PTR)
+			{
+				args[iterator] = value_create_ptr(va_arg(va, const void *));
+			}
+			else
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Calling metacallt with unsupported type '%s', using null type instead", type_id_name(id));
+				args[iterator] = metacall_value_create_null();
+			}
+		}
+
+		va_end(va);
+
+		ret = function_call(f, args, args_count);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			value_type_destroy(args[iterator]);
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallt_s(const char *name, const enum metacall_value_id ids[], size_t size, ...)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		value ret = NULL;
+
+		signature s = function_signature(f);
+
+		size_t iterator;
+
+		va_list va;
+
+		va_start(va, size);
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			type t = signature_get_type(s, iterator);
+
+			type_id id = type_index(t);
+
+			if (t != NULL)
+			{
+				id = type_index(t);
+			}
+			else
+			{
+				id = ids[iterator];
+			}
+
+			if (id == TYPE_BOOL)
+			{
+				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
+			}
+			if (id == TYPE_CHAR)
+			{
+				args[iterator] = value_create_char((char)va_arg(va, int));
+			}
+			else if (id == TYPE_SHORT)
+			{
+				args[iterator] = value_create_short((short)va_arg(va, int));
+			}
+			else if (id == TYPE_INT)
+			{
+				args[iterator] = value_create_int(va_arg(va, int));
+			}
+			else if (id == TYPE_LONG)
+			{
+				args[iterator] = value_create_long(va_arg(va, long));
+			}
+			else if (id == TYPE_FLOAT)
+			{
+				args[iterator] = value_create_float((float)va_arg(va, double));
+			}
+			else if (id == TYPE_DOUBLE)
+			{
+				args[iterator] = value_create_double(va_arg(va, double));
+			}
+			else if (id == TYPE_STRING)
+			{
+				const char *str = va_arg(va, const char *);
+
+				args[iterator] = value_create_string(str, strlen(str));
+			}
+			else if (id == TYPE_PTR)
+			{
+				args[iterator] = value_create_ptr(va_arg(va, const void *));
+			}
+			else
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Calling metacallt_s with unsupported type '%s', using null type instead", type_id_name(id));
+				args[iterator] = metacall_value_create_null();
+			}
+		}
+
+		va_end(va);
+
+		ret = function_call(f, args, size);
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			value_type_destroy(args[iterator]);
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallht_s(void *handle, const char *name, const enum metacall_value_id ids[], size_t size, ...)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacallht_s is not valid", handle);
+		return NULL;
+	}
+
+	value f_val = loader_handle_get(handle, name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		value ret = NULL;
+
+		signature s = function_signature(f);
+
+		size_t iterator;
+
+		va_list va;
+
+		va_start(va, size);
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			type t = signature_get_type(s, iterator);
+
+			type_id id = type_index(t);
+
+			if (t != NULL)
+			{
+				id = type_index(t);
+			}
+			else
+			{
+				id = ids[iterator];
+			}
+
+			if (id == TYPE_BOOL)
+			{
+				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
+			}
+			if (id == TYPE_CHAR)
+			{
+				args[iterator] = value_create_char((char)va_arg(va, int));
+			}
+			else if (id == TYPE_SHORT)
+			{
+				args[iterator] = value_create_short((short)va_arg(va, int));
+			}
+			else if (id == TYPE_INT)
+			{
+				args[iterator] = value_create_int(va_arg(va, int));
+			}
+			else if (id == TYPE_LONG)
+			{
+				args[iterator] = value_create_long(va_arg(va, long));
+			}
+			else if (id == TYPE_FLOAT)
+			{
+				args[iterator] = value_create_float((float)va_arg(va, double));
+			}
+			else if (id == TYPE_DOUBLE)
+			{
+				args[iterator] = value_create_double(va_arg(va, double));
+			}
+			else if (id == TYPE_STRING)
+			{
+				const char *str = va_arg(va, const char *);
+
+				args[iterator] = value_create_string(str, strlen(str));
+			}
+			else if (id == TYPE_PTR)
+			{
+				args[iterator] = value_create_ptr(va_arg(va, const void *));
+			}
+			else
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Calling metacallht_s with unsupported type '%s', using null type instead", type_id_name(id));
+				args[iterator] = metacall_value_create_null();
+			}
+		}
+
+		va_end(va);
+
+		ret = function_call(f, args, size);
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			value_type_destroy(args[iterator]);
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacall_function(const char *name)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return f;
+}
+
+int metacall_handle_initialize(void *loader, const char *name, void **handle_ptr)
+{
+	if (loader == NULL)
+	{
+		return 1;
+	}
+
+	return loader_handle_initialize(loader, name, handle_ptr);
+}
+
+int metacall_handle_populate(void *handle_dest, void *handle_src)
+{
+	if (handle_dest == NULL || handle_src == NULL)
+	{
+		return 1;
+	}
+
+	return loader_handle_populate(handle_dest, handle_src);
+}
+
+void *metacall_handle_function(void *handle, const char *name)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_handle_function is not valid", handle);
+		return NULL;
+	}
+
+	value f_val = loader_handle_get(handle, name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return f;
+}
+
+int metacall_function_parameter_type(void *func, size_t parameter, enum metacall_value_id *id)
+{
+	if (func != NULL)
+	{
+		function f = (function)func;
+		signature s = function_signature(f);
+
+		if (parameter < signature_count(s))
+		{
+			*id = type_index(signature_get_type(s, parameter));
+
+			return 0;
+		}
+	}
+
+	*id = METACALL_INVALID;
+
+	return 1;
+}
+
+int metacall_function_return_type(void *func, enum metacall_value_id *id)
+{
+	if (func != NULL)
+	{
+		function f = (function)func;
+		signature s = function_signature(f);
+
+		*id = type_index(signature_get_return(s));
+
+		return 0;
+	}
+
+	*id = METACALL_INVALID;
+
+	return 1;
+}
+
+size_t metacall_function_size(void *func)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		return signature_count(s);
+	}
+
+	return 0;
+}
+
+int metacall_function_async(void *func)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		return function_async_id(f);
+	}
+
+	return -1;
+}
+
+void *metacall_handle(const char *tag, const char *name)
+{
+	return (void *)loader_get_handle(tag, name);
+}
+
+const char *metacall_handle_id(void *handle)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement error handling
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_handle_id is not valid", handle);
+		return NULL;
+	}
+
+	return loader_handle_id(handle);
+}
+
+void *metacall_handle_export(void *handle)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_handle_export is not valid", handle);
+		return NULL;
+	}
+
+	return loader_handle_export(handle);
+}
+
+void *metacallfv(void *func, void *args[])
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		return metacallfv_s(func, args, signature_count(s));
+	}
+
+	return NULL;
+}
+
+void *metacallfv_s(void *func, void *args[], size_t size)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		size_t iterator;
+
+		value ret;
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			if (value_validate(args[iterator]) != 0)
+			{
+				const char *name = function_name(f);
+
+				if (name == NULL)
+				{
+					name = "anonymous";
+				}
+
+				// TODO: Implement type error return a value
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid argument at position %" PRIuS " when calling to metacallfv_s with function <%s> and value <%p>", iterator, name, args[iterator]);
+				return NULL;
+			}
+
+			type t = signature_get_type(s, iterator);
+
+			if (t != NULL)
+			{
+				type_id id = type_index(t);
+
+				if (id != value_type_id((value)args[iterator]))
+				{
+					value cast_arg = value_type_cast((value)args[iterator], id);
+
+					if (cast_arg != NULL)
+					{
+						args[iterator] = cast_arg;
+					}
+				}
+			}
+		}
+
+		ret = function_call(f, args, size);
+
+		if (ret != NULL)
+		{
+			type t = signature_get_return(s);
+
+			if (t != NULL)
+			{
+				type_id id = type_index(t);
+
+				if (id != value_type_id(ret))
+				{
+					value cast_ret = value_type_cast(ret, id);
+
+					return (cast_ret == NULL) ? ret : cast_ret;
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallf(void *func, ...)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		value ret = NULL;
+
+		signature s = function_signature(f);
+
+		size_t iterator, args_count = signature_count(s);
+
+		va_list va;
+
+		va_start(va, func);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			type t = signature_get_type(s, iterator);
+
+			type_id id = type_index(t);
+
+			if (id == TYPE_BOOL)
+			{
+				args[iterator] = value_create_bool((boolean)va_arg(va, unsigned int));
+			}
+			if (id == TYPE_CHAR)
+			{
+				args[iterator] = value_create_char((char)va_arg(va, int));
+			}
+			else if (id == TYPE_SHORT)
+			{
+				args[iterator] = value_create_short((short)va_arg(va, int));
+			}
+			else if (id == TYPE_INT)
+			{
+				args[iterator] = value_create_int(va_arg(va, int));
+			}
+			else if (id == TYPE_LONG)
+			{
+				args[iterator] = value_create_long(va_arg(va, long));
+			}
+			else if (id == TYPE_FLOAT)
+			{
+				args[iterator] = value_create_float((float)va_arg(va, double));
+			}
+			else if (id == TYPE_DOUBLE)
+			{
+				args[iterator] = value_create_double(va_arg(va, double));
+			}
+			else if (id == TYPE_STRING)
+			{
+				const char *str = va_arg(va, const char *);
+
+				args[iterator] = value_create_string(str, strlen(str));
+			}
+			else if (id == TYPE_PTR)
+			{
+				args[iterator] = value_create_ptr(va_arg(va, const void *));
+			}
+			else
+			{
+				log_write("metacall", LOG_LEVEL_ERROR, "Calling metacallf with unsupported type '%s', using null type instead", type_id_name(id));
+				args[iterator] = metacall_value_create_null();
+			}
+		}
+
+		va_end(va);
+
+		ret = function_call(f, args, args_count);
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			value_type_destroy(args[iterator]);
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallfs(void *func, const char *buffer, size_t size, void *allocator)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		if (buffer == NULL || size == 0)
+		{
+			if (signature_count(s) == 0)
+			{
+				value ret = function_call(f, metacall_null_args, 0);
+
+				if (ret != NULL)
+				{
+					type t = signature_get_return(s);
+
+					if (t != NULL)
+					{
+						type_id id = type_index(t);
+
+						if (id != value_type_id(ret))
+						{
+							value cast_ret = value_type_cast(ret, id);
+
+							return (cast_ret == NULL) ? ret : cast_ret;
+						}
+					}
+				}
+
+				return ret;
+			}
+
+			return NULL;
+		}
+		else
+		{
+			void *args[METACALL_ARGS_SIZE];
+
+			value *v_array, ret, v = (value)metacall_deserialize(metacall_serial(), buffer, size, allocator);
+
+			size_t iterator, args_count;
+
+			if (v == NULL)
+			{
+				return NULL;
+			}
+
+			if (type_id_array(value_type_id(v)) != 0)
+			{
+				value_type_destroy(v);
+
+				return NULL;
+			}
+
+			args_count = value_type_count(v);
+
+			v_array = value_to_array(v);
+
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				/* This step is necessary in order to handle type castings */
+				args[iterator] = metacall_value_copy(v_array[iterator]);
+			}
+
+			ret = metacallfv_s(f, args, args_count);
+
+			/* This step is necessary in order to handle type castings (otherwise it generates leaks) */
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value_type_destroy(args[iterator]);
+			}
+
+			value_type_destroy(v);
+
+			if (ret != NULL)
+			{
+				type t = signature_get_return(s);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id(ret))
+					{
+						value cast_ret = value_type_cast(ret, id);
+
+						if (cast_ret != NULL)
+						{
+							ret = cast_ret;
+						}
+					}
+				}
+			}
+
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+
+void *metacallfmv(void *func, void *keys[], void *values[])
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		signature s = function_signature(f);
+
+		size_t iterator, args_count = signature_count(s);
+
+		value ret;
+
+		for (iterator = 0; iterator < args_count; ++iterator)
+		{
+			if (value_validate(keys[iterator]) != 0)
+			{
+				// TODO: Implement type error return a value
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid key at position %" PRIuS " when calling to metacallfmv", iterator);
+				return NULL;
+			}
+
+			if (value_validate(values[iterator]) != 0)
+			{
+				// TODO: Implement type error return a value
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid value at position %" PRIuS " when calling to metacallfmv", iterator);
+				return NULL;
+			}
+
+			type_id key_id = value_type_id((value)keys[iterator]);
+
+			size_t index = METACALL_ARGS_SIZE;
+
+			/* Obtain signature index */
+			if (type_id_string(key_id) == 0)
+			{
+				const char *key = value_to_string(keys[iterator]);
+
+				index = signature_get_index(s, key);
+			}
+			else if (type_id_integer(key_id) == 0)
+			{
+				value cast_key = value_type_cast((value)keys[iterator], TYPE_INT);
+
+				int key_index;
+
+				if (cast_key != NULL)
+				{
+					keys[iterator] = cast_key;
+				}
+
+				key_index = value_to_int((value)keys[iterator]);
+
+				if (key_index >= 0 && key_index < METACALL_ARGS_SIZE)
+				{
+					index = (size_t)key_index;
+				}
+			}
+
+			/* If index is valid, cast values and build arguments */
+			if (index < METACALL_ARGS_SIZE)
+			{
+				type t = signature_get_type(s, iterator);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id((value)values[iterator]))
+					{
+						value cast_arg = value_type_cast((value)values[iterator], id);
+
+						if (cast_arg != NULL)
+						{
+							values[iterator] = cast_arg;
+						}
+					}
+				}
+
+				args[index] = values[iterator];
+			}
+			else
+			{
+				/* TODO: Handle properly exceptions */
+				return NULL;
+			}
+		}
+
+		ret = function_call(f, args, args_count);
+
+		if (ret != NULL)
+		{
+			type t = signature_get_return(s);
+
+			if (t != NULL)
+			{
+				type_id id = type_index(t);
+
+				if (id != value_type_id(ret))
+				{
+					value cast_ret = value_type_cast(ret, id);
+
+					return (cast_ret == NULL) ? ret : cast_ret;
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallfms(void *func, const char *buffer, size_t size, void *allocator)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		if (buffer == NULL || size == 0)
+		{
+			if (signature_count(s) == 0)
+			{
+				value ret = function_call(f, metacall_null_args, 0);
+
+				if (ret != NULL)
+				{
+					type t = signature_get_return(s);
+
+					if (t != NULL)
+					{
+						type_id id = type_index(t);
+
+						if (id != value_type_id(ret))
+						{
+							value cast_ret = value_type_cast(ret, id);
+
+							return (cast_ret == NULL) ? ret : cast_ret;
+						}
+					}
+				}
+
+				return ret;
+			}
+
+			return NULL;
+		}
+		else
+		{
+			void *keys[METACALL_ARGS_SIZE];
+			void *values[METACALL_ARGS_SIZE];
+
+			value *v_map, ret, v = (value)metacall_deserialize(metacall_serial(), buffer, size, allocator);
+
+			size_t iterator, args_count;
+
+			if (v == NULL)
+			{
+				return NULL;
+			}
+
+			if (type_id_map(value_type_id(v)) != 0)
+			{
+				value_type_destroy(v);
+				return NULL;
+			}
+
+			args_count = signature_count(s);
+
+			/* TODO: No optional arguments allowed, review in the future */
+			if (args_count != value_type_count(v))
+			{
+				value_type_destroy(v);
+				return NULL;
+			}
+
+			v_map = value_to_map(v);
+
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value element = v_map[iterator];
+				value *v_element = value_to_array(element);
+
+				/* This step is necessary in order to handle type castings */
+				keys[iterator] = value_type_copy(v_element[0]);
+				values[iterator] = value_type_copy(v_element[1]);
+			}
+
+			ret = metacallfmv(f, keys, values);
+
+			/* This step is necessary in order to handle type castings (otherwise it generates leaks) */
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value_type_destroy(keys[iterator]);
+				value_type_destroy(values[iterator]);
+			}
+
+			value_type_destroy(v);
+
+			if (ret != NULL)
+			{
+				type t = signature_get_return(s);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id(ret))
+					{
+						value cast_ret = value_type_cast(ret, id);
+
+						if (cast_ret != NULL)
+						{
+							ret = cast_ret;
+						}
+					}
+				}
+			}
+
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+
+int metacall_register(const char *name, void *(*invoke)(size_t, void *[], void *), void **func, enum metacall_value_id return_type, size_t size, ...)
+{
+	type_id types[METACALL_ARGS_SIZE];
+
+	va_list va;
+
+	va_start(va, size);
+
+	size_t iterator;
+
+	for (iterator = 0; iterator < size; ++iterator)
+	{
+		types[iterator] = (type_id)va_arg(va, int);
+	}
+
+	va_end(va);
+
+	return loader_register(name, (loader_register_invoke)invoke, (function *)func, (type_id)return_type, size, (type_id *)types);
+}
+
+int metacall_registerv(const char *name, void *(*invoke)(size_t, void *[], void *), void **func, enum metacall_value_id return_type, size_t size, enum metacall_value_id types[])
+{
+	return loader_register(name, (loader_register_invoke)invoke, (function *)func, (type_id)return_type, size, (type_id *)types);
+}
+
+void *metacall_loader(const char *tag)
+{
+	return loader_get_impl(tag);
+}
+
+int metacall_register_loaderv(void *loader, void *handle, const char *name, void *(*invoke)(size_t, void *[], void *), enum metacall_value_id return_type, size_t size, enum metacall_value_id types[])
+{
+	return loader_register_impl(loader, handle, name, (loader_register_invoke)invoke, (type_id)return_type, size, (type_id *)types);
+}
+
+void *metacall_await(const char *name, void *args[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	signature s = function_signature(f);
+
+	return function_await(f, args, signature_count(s), resolve_callback, reject_callback, data);
+}
+
+void *metacall_await_future(void *f, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	if (f != NULL)
+	{
+		return future_await((future)f, resolve_callback, reject_callback, data);
+	}
+
+	// TODO: Error handling
+	return NULL;
+}
+
+void *metacall_await_s(const char *name, void *args[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	value f_val = loader_get(name);
+	function f = NULL;
+
+	if (value_type_id(f_val) == TYPE_FUNCTION)
+	{
+		f = value_to_function(f_val);
+	}
+
+	return function_await(f, args, size, resolve_callback, reject_callback, data);
+}
+
+void *metacallfv_await(void *func, void *args[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	function f = (function)func;
+
+	signature s = function_signature(f);
+
+	return function_await(func, args, signature_count(s), resolve_callback, reject_callback, data);
+}
+
+void *metacallfv_await_s(void *func, void *args[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	return function_await(func, args, size, resolve_callback, reject_callback, data);
+}
+
+void *metacallfv_await_struct_s(void *func, void *args[], size_t size, metacall_await_callbacks cb, void *data)
+{
+	return function_await(func, args, size, cb.resolve, cb.reject, data);
+}
+
+void *metacallfmv_await(void *func, void *keys[], void *values[], void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		return metacallfmv_await_s(func, keys, values, signature_count(s), resolve_callback, reject_callback, data);
+	}
+
+	// TODO: Error handling
+	return NULL;
+}
+
+/* TODO: Unify code between metacallfmv and metacallfmv_await_s */
+void *metacallfmv_await_s(void *func, void *keys[], void *values[], size_t size, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		void *args[METACALL_ARGS_SIZE];
+
+		signature s = function_signature(f);
+
+		size_t iterator;
+
+		value ret;
+
+		for (iterator = 0; iterator < size; ++iterator)
+		{
+			if (value_validate(keys[iterator]) != 0)
+			{
+				// TODO: Implement type error return a value
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid key at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
+				return NULL;
+			}
+
+			if (value_validate(values[iterator]) != 0)
+			{
+				// TODO: Implement type error return a value
+				log_write("metacall", LOG_LEVEL_ERROR, "Invalid value at position %" PRIuS " when calling to metacallfmv_await_s", iterator);
+				return NULL;
+			}
+
+			type_id key_id = value_type_id((value)keys[iterator]);
+
+			size_t index = METACALL_ARGS_SIZE;
+
+			/* Obtain signature index */
+			if (type_id_string(key_id) == 0)
+			{
+				const char *key = value_to_string(keys[iterator]);
+
+				index = signature_get_index(s, key);
+			}
+			else if (type_id_integer(key_id) == 0)
+			{
+				value cast_key = value_type_cast((value)keys[iterator], TYPE_INT);
+
+				int key_index;
+
+				if (cast_key != NULL)
+				{
+					keys[iterator] = cast_key;
+				}
+
+				key_index = value_to_int((value)keys[iterator]);
+
+				if (key_index >= 0 && key_index < METACALL_ARGS_SIZE)
+				{
+					index = (size_t)key_index;
+				}
+			}
+
+			/* If index is valid, cast values and build arguments */
+			if (index < METACALL_ARGS_SIZE)
+			{
+				type t = signature_get_type(s, iterator);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id((value)values[iterator]))
+					{
+						value cast_arg = value_type_cast((value)values[iterator], id);
+
+						if (cast_arg != NULL)
+						{
+							values[iterator] = cast_arg;
+						}
+					}
+				}
+
+				args[index] = values[iterator];
+			}
+			else
+			{
+				/* TODO: Handle properly exceptions */
+				return NULL;
+			}
+		}
+
+		ret = function_await(f, args, size, resolve_callback, reject_callback, data);
+
+		if (ret != NULL)
+		{
+			type t = signature_get_return(s);
+
+			if (t != NULL)
+			{
+				type_id id = type_index(t);
+
+				if (id != value_type_id(ret))
+				{
+					value cast_ret = value_type_cast(ret, id);
+
+					return (cast_ret == NULL) ? ret : cast_ret;
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	return NULL;
+}
+
+void *metacallfs_await(void *func, const char *buffer, size_t size, void *allocator, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		if (buffer == NULL || size == 0)
+		{
+			if (signature_count(s) == 0)
+			{
+				value ret = function_await(f, metacall_null_args, 0, resolve_callback, reject_callback, data);
+
+				if (ret != NULL)
+				{
+					type t = signature_get_return(s);
+
+					if (t != NULL)
+					{
+						type_id id = type_index(t);
+
+						if (id != value_type_id(ret))
+						{
+							value cast_ret = value_type_cast(ret, id);
+
+							return (cast_ret == NULL) ? ret : cast_ret;
+						}
+					}
+				}
+
+				return ret;
+			}
+
+			return NULL;
+		}
+		else
+		{
+			void *args[METACALL_ARGS_SIZE];
+
+			value *v_array, ret, v = (value)metacall_deserialize(metacall_serial(), buffer, size, allocator);
+
+			size_t iterator, args_count;
+
+			if (v == NULL)
+			{
+				return NULL;
+			}
+
+			if (type_id_array(value_type_id(v)) != 0)
+			{
+				value_type_destroy(v);
+
+				return NULL;
+			}
+
+			args_count = value_type_count(v);
+
+			v_array = value_to_array(v);
+
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				/* This step is necessary in order to handle type castings */
+				args[iterator] = value_type_copy(v_array[iterator]);
+			}
+
+			ret = metacallfv_await(f, args, resolve_callback, reject_callback, data);
+
+			/* This step is necessary in order to handle type castings (otherwise it generates leaks) */
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value_type_destroy(args[iterator]);
+			}
+
+			value_type_destroy(v);
+
+			if (ret != NULL)
+			{
+				type t = signature_get_return(s);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id(ret))
+					{
+						value cast_ret = value_type_cast(ret, id);
+
+						if (cast_ret != NULL)
+						{
+							ret = cast_ret;
+						}
+					}
+				}
+			}
+
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+
+/* TODO: Unify code between metacallfms and metacallfms_await */
+void *metacallfms_await(void *func, const char *buffer, size_t size, void *allocator, void *(*resolve_callback)(void *, void *), void *(*reject_callback)(void *, void *), void *data)
+{
+	function f = (function)func;
+
+	if (f != NULL)
+	{
+		signature s = function_signature(f);
+
+		if (buffer == NULL || size == 0)
+		{
+			if (signature_count(s) == 0)
+			{
+				value ret = function_await(f, metacall_null_args, 0, resolve_callback, reject_callback, data);
+
+				if (ret != NULL)
+				{
+					type t = signature_get_return(s);
+
+					if (t != NULL)
+					{
+						type_id id = type_index(t);
+
+						if (id != value_type_id(ret))
+						{
+							value cast_ret = value_type_cast(ret, id);
+
+							return (cast_ret == NULL) ? ret : cast_ret;
+						}
+					}
+				}
+
+				return ret;
+			}
+
+			return NULL;
+		}
+		else
+		{
+			void *keys[METACALL_ARGS_SIZE];
+			void *values[METACALL_ARGS_SIZE];
+
+			value *v_map, ret, v = (value)metacall_deserialize(metacall_serial(), buffer, size, allocator);
+
+			size_t iterator, args_count;
+
+			if (v == NULL)
+			{
+				return NULL;
+			}
+
+			if (type_id_map(value_type_id(v)) != 0)
+			{
+				value_type_destroy(v);
+
+				return NULL;
+			}
+
+			args_count = signature_count(s);
+
+			/* TODO: No optional arguments allowed, review in the future */
+			if (args_count != value_type_count(v))
+			{
+				value_type_destroy(v);
+
+				return NULL;
+			}
+
+			v_map = value_to_map(v);
+
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value element = v_map[iterator];
+				value *v_element = value_to_array(element);
+
+				/* This step is necessary in order to handle type castings */
+				keys[iterator] = value_type_copy(v_element[0]);
+				values[iterator] = value_type_copy(v_element[1]);
+			}
+
+			ret = metacallfmv_await(f, keys, values, resolve_callback, reject_callback, data);
+
+			/* This step is necessary in order to handle type castings (otherwise it generates leaks) */
+			for (iterator = 0; iterator < args_count; ++iterator)
+			{
+				value_type_destroy(keys[iterator]);
+				value_type_destroy(values[iterator]);
+			}
+
+			value_type_destroy(v);
+
+			if (ret != NULL)
+			{
+				type t = signature_get_return(s);
+
+				if (t != NULL)
+				{
+					type_id id = type_index(t);
+
+					if (id != value_type_id(ret))
+					{
+						value cast_ret = value_type_cast(ret, id);
+
+						if (cast_ret != NULL)
+						{
+							ret = cast_ret;
+						}
+					}
+				}
+			}
+
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+
+void *metacall_class(const char *name)
+{
+	value c_val = loader_get(name);
+	klass c = NULL;
+
+	if (value_type_id(c_val) == TYPE_CLASS)
+	{
+		c = value_to_class(c_val);
+	}
+
+	return c;
+}
+
+void *metacall_class_new(void *cls, const char *name, void *args[], size_t size)
+{
+	type_id *ids = metacall_type_ids(args, size);
+
+	constructor ctor = class_constructor(cls, ids, size);
+
+	object o = class_new(cls, name, ctor, args, size);
+
+	if (ids != NULL)
+	{
+		free(ids);
+	}
+
+	if (o == NULL)
+	{
+		return NULL;
+	}
+
+	value v = value_create_object(o);
+
+	if (v == NULL)
+	{
+		object_destroy(o);
+	}
+
+	return v;
+}
+
+void *metacall_class_static_get(void *cls, const char *key)
+{
+	return class_static_get(cls, key);
+}
+
+int metacall_class_static_set(void *cls, const char *key, void *v)
+{
+	return class_static_set(cls, key, v);
+}
+
+void *metacallv_method(void *target, const char *name, method_invoke_ptr call, vector v, void *args[], size_t size)
+{
+	if (v == NULL)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is not implemented (bad allocation)", name, target);
+		return NULL;
+	}
+
+	if (vector_size(v) == 0)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is not implemented", name, target);
+		vector_destroy(v);
+		return NULL;
+	}
+
+	if (vector_size(v) > 1)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is overloaded, you should use 'metacallt_class' instead for disambiguate the call", name, target);
+		vector_destroy(v);
+		return NULL;
+	}
+
+	method m = vector_at_type(v, 0, method);
+
+	if (m == NULL)
+	{
+		// TODO: Implement type error return a value
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in %p is invalid (NULL)", name, target);
+		vector_destroy(v);
+		return NULL;
+	}
+
+	signature s = method_signature(m);
+	size_t iterator;
+
+	for (iterator = 0; iterator < size; ++iterator)
+	{
+		if (value_validate(args[iterator]) != 0)
+		{
+			const char *name = method_name(m);
+
+			if (name == NULL)
+			{
+				name = "anonymous";
+			}
+
+			// TODO: Implement type error return a value
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid argument at position %" PRIuS " when calling to metacallv_method with method <%s> and value <%p>", iterator, name, args[iterator]);
+			vector_destroy(v);
+			return NULL;
+		}
+
+		type t = signature_get_type(s, iterator);
+
+		if (t != NULL)
+		{
+			type_id id = type_index(t);
+
+			if (id != value_type_id((value)args[iterator]))
+			{
+				value cast_arg = value_type_cast((value)args[iterator], id);
+
+				if (cast_arg != NULL)
+				{
+					args[iterator] = cast_arg;
+				}
+			}
+		}
+	}
+
+	value ret = call(target, m, args, size);
+
+	vector_destroy(v);
+
+	if (ret != NULL)
+	{
+		type t = signature_get_return(s);
+
+		if (t != NULL)
+		{
+			type_id id = type_index(t);
+
+			if (id != value_type_id(ret))
+			{
+				value cast_ret = value_type_cast(ret, id);
+
+				return (cast_ret == NULL) ? ret : cast_ret;
+			}
+		}
+	}
+
+	return ret;
+}
+
+void *metacallv_class(void *cls, const char *name, void *args[], size_t size)
+{
+	return metacallv_method(cls, name, (method_invoke_ptr)&class_static_call, class_static_methods(cls, name), args, size);
+}
+
+type_id *metacall_type_ids(void *args[], size_t size)
+{
+	type_id *ids = NULL;
+
+	if (size > 0)
+	{
+		ids = (type_id *)malloc(sizeof(type_id) * size);
+
+		for (size_t iterator = 0; iterator < size; ++iterator)
+		{
+			ids[iterator] = metacall_value_id(args[iterator]);
+		}
+	}
+
+	return ids;
+}
+
+void *metacallt_class(void *cls, const char *name, const enum metacall_value_id ret, void *args[], size_t size)
+{
+	type_id *ids = metacall_type_ids(args, size);
+
+	method m = class_static_method(cls, name, ret, ids, size);
+
+	if (ids != NULL)
+	{
+		free(ids);
+	}
+
+	if (m == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in class <%p> is not implemented with the parameter types being received", name, cls);
+		return NULL;
+	}
+
+	return class_static_call(cls, m, args, size);
+}
+
+void *metacallv_object(void *obj, const char *name, void *args[], size_t size)
+{
+	return metacallv_method(obj, name, (method_invoke_ptr)&object_call, object_methods(obj, name), args, size);
+}
+
+void *metacallt_object(void *obj, const char *name, const enum metacall_value_id ret, void *args[], size_t size)
+{
+	type_id *ids = NULL;
+
+	if (size > 0)
+	{
+		ids = (type_id *)malloc(sizeof(type_id) * size);
+
+		for (size_t iterator = 0; iterator < size; ++iterator)
+		{
+			ids[iterator] = metacall_value_id(args[iterator]);
+		}
+	}
+
+	method m = object_method(obj, name, ret, ids, size);
+
+	if (ids != NULL)
+	{
+		free(ids);
+	}
+
+	if (m == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Method %s in object <%p> is not implemented with the parameter types being received", name, obj);
+		return NULL;
+	}
+
+	return object_call(obj, m, args, size);
+}
+
+void *metacall_object_get(void *obj, const char *key)
+{
+	return object_get(obj, key);
+}
+
+int metacall_object_set(void *obj, const char *key, void *v)
+{
+	return object_set(obj, key, v);
+}
+
+void *metacall_throwable_value(void *th)
+{
+	return throwable_value(th);
+}
+
+char *metacall_inspect(size_t *size, void *allocator)
+{
+	serial s;
+
+	value v = loader_metadata();
+
+	char *str;
+
+	if (v == NULL)
+	{
+		v = value_create_map(NULL, 0);
+
+		if (v == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid MetaCall inspect map creation");
+
+			return NULL;
+		}
+	}
+
+	s = serial_create(metacall_serial());
+
+	str = serial_serialize(s, v, size, allocator);
+
+	value_type_destroy(v);
+
+	return str;
+}
+
+void *metacall_inspect_value(void)
+{
+	return loader_metadata();
+}
+
+char *metacall_serialize(const char *name, void *v, size_t *size, void *allocator)
+{
+	serial s = serial_create(name);
+
+	return serial_serialize(s, (value)v, size, (memory_allocator)allocator);
+}
+
+void *metacall_deserialize(const char *name, const char *buffer, size_t size, void *allocator)
+{
+	serial s = serial_create(name);
+
+	return (void *)serial_deserialize(s, buffer, size, (memory_allocator)allocator);
+}
+
+int metacall_clear(void *handle)
+{
+	if (loader_impl_handle_validate(handle) != 0)
+	{
+		/* TODO: Implement error handling */
+		log_write("metacall", LOG_LEVEL_ERROR, "Handle %p passed to metacall_clear is not valid", handle);
+		return 1;
+	}
+
+	return loader_clear(handle);
+}
+
+void *metacall_plugin_extension(void)
+{
+	return plugin_extension_handle;
+}
+
+void *metacall_plugin_core(void)
+{
+	return plugin_core_handle;
+}
+
+const char *metacall_plugin_path(void)
+{
+	if (plugin_extension_handle == NULL)
+	{
+		return NULL;
+	}
+
+	return plugin_path;
+}
+
+void metacall_destroy(void)
+{
+	if (metacall_initialize_flag == 0)
+	{
+		/* Destroy loaders */
+		loader_destroy();
+
+		/* Destroy configurations */
+		configuration_destroy();
+
+		/* Print stats from functions, classes, objects and exceptions */
+		reflect_memory_tracker_debug();
+
+		/* Set to null the plugin extension and core plugin handles */
+		plugin_extension_handle = NULL;
+		plugin_core_handle = NULL;
+
+		/* Set initialization flag to destroyed */
+		metacall_initialize_flag = 1;
+	}
+}
+
+const struct metacall_version_type *metacall_version(void)
+{
+	static const struct metacall_version_type version = {
+		METACALL_VERSION_MAJOR_ID,
+		METACALL_VERSION_MINOR_ID,
+		METACALL_VERSION_PATCH_ID,
+		METACALL_VERSION_REVISION,
+		METACALL_VERSION,
+		METACALL_NAME_VERSION
+	};
+
+	return &version;
+}
+
+uint32_t metacall_version_hex_make(unsigned int major, unsigned int minor, unsigned int patch)
+{
+	const uint32_t version_hex = (major << 0x18) + (minor << 0x10) + patch;
+
+	return version_hex;
+}
+
+uint32_t metacall_version_hex(void)
+{
+	static const uint32_t version_hex =
+		(METACALL_VERSION_MAJOR_ID << 0x18) +
+		(METACALL_VERSION_MINOR_ID << 0x10) +
+		METACALL_VERSION_PATCH_ID;
+
+	return version_hex;
+}
+
+const char *metacall_version_str(void)
+{
+	static const char version_string[] = METACALL_VERSION;
+
+	return version_string;
+}
+
+const char *metacall_version_revision(void)
+{
+	static const char version_revision[] = METACALL_VERSION_REVISION;
+
+	return version_revision;
+}
+
+const char *metacall_version_name(void)
+{
+	static const char version_name[] = METACALL_NAME_VERSION;
+
+	return version_name;
+}
+
+const char *metacall_print_info(void)
+{
+	static const char metacall_info[] =
+		"MetaCall Library " METACALL_VERSION "\n"
+		"Copyright (C) 2016 - 2025 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>\n"
+
+#ifdef METACALL_STATIC_DEFINE
+		"Compiled as static library type"
+#else
+		"Compiled as shared library type"
+#endif
+
+		"\n";
+
+	return metacall_info;
+}

--- a/source/metacall/source/metacall_allocator.c
+++ b/source/metacall/source/metacall_allocator.c
@@ -1,0 +1,51 @@
+
+/* -- Headers -- */
+
+#include <metacall/metacall_allocator.h>
+
+#include <memory/memory.h>
+
+/* -- Methods -- */
+
+void *metacall_allocator_create(enum metacall_allocator_id allocator_id, void *ctx)
+{
+	switch (allocator_id)
+	{
+		case METACALL_ALLOCATOR_STD: {
+			metacall_allocator_std std_ctx = (metacall_allocator_std)ctx;
+
+			return memory_allocator_std(std_ctx->malloc, std_ctx->realloc, std_ctx->free);
+		}
+
+		case METACALL_ALLOCATOR_NGINX: {
+			metacall_allocator_nginx nginx_ctx = (metacall_allocator_nginx)ctx;
+
+			return memory_allocator_nginx((void *)nginx_ctx->pool,
+				(memory_allocator_nginx_impl_palloc)nginx_ctx->palloc,
+				(memory_allocator_nginx_impl_pcopy)nginx_ctx->pcopy,
+				(memory_allocator_nginx_impl_pfree)nginx_ctx->pfree);
+		}
+	}
+
+	return NULL;
+}
+
+void *metacall_allocator_alloc(void *allocator, size_t size)
+{
+	return memory_allocator_allocate((memory_allocator)allocator, size);
+}
+
+void *metacall_allocator_realloc(void *allocator, void *data, size_t size, size_t new_size)
+{
+	return memory_allocator_reallocate((memory_allocator)allocator, data, size, new_size);
+}
+
+void metacall_allocator_free(void *allocator, void *data)
+{
+	memory_allocator_deallocate((memory_allocator)allocator, data);
+}
+
+void metacall_allocator_destroy(void *allocator)
+{
+	memory_allocator_destroy((memory_allocator)allocator);
+}

--- a/source/metacall/source/metacall_error.c
+++ b/source/metacall/source/metacall_error.c
@@ -1,0 +1,51 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall_error.h>
+
+#include <reflect/reflect_value_type.h>
+
+#include <log/log.h>
+
+/* -- Methods -- */
+
+int metacall_error_from_value(void *v, metacall_exception ex)
+{
+	if (v == NULL || ex == NULL)
+	{
+		return 1;
+	}
+
+	if (type_id_throwable(value_type_id(v)) == 0)
+	{
+		v = throwable_value(value_to_throwable(v));
+	}
+
+	if (type_id_exception(value_type_id(v)) != 0)
+	{
+		return 1;
+	}
+
+	void *ex_impl = value_to_exception(v);
+
+	ex->message = exception_message(ex_impl);
+	ex->label = exception_label(ex_impl);
+	ex->code = exception_error_code(ex_impl);
+	ex->stacktrace = exception_stacktrace(ex_impl);
+
+	return 0;
+}
+
+int metacall_error_last(metacall_exception ex)
+{
+	// TODO
+	(void)ex;
+
+	return 1;
+}
+
+void metacall_error_clear(void)
+{
+	// TODO
+}

--- a/source/metacall/source/metacall_fork.c
+++ b/source/metacall/source/metacall_fork.c
@@ -1,0 +1,310 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall.h>
+#include <metacall/metacall_fork.h>
+
+#include <detour/detour.h>
+
+#include <log/log.h>
+
+#include <stdlib.h>
+
+/* -- Methods -- */
+
+#if defined(WIN32) || defined(_WIN32) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	defined(__MINGW32__) || defined(__MINGW64__)
+
+/* -- Headers -- */
+
+	#ifndef _WIN32_WINNT
+		#define _WIN32_WINNT 0x0600
+	#endif
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
+	#include <windows.h>
+
+/* -- Type Definitions -- */
+
+typedef long NTSTATUS;
+
+typedef struct _CLIENT_ID
+{
+	PVOID UniqueProcess;
+	PVOID UniqueThread;
+} CLIENT_ID, *PCLIENT_ID;
+
+typedef struct _SECTION_IMAGE_INFORMATION
+{
+	PVOID EntryPoint;
+	ULONG StackZeroBits;
+	ULONG StackReserved;
+	ULONG StackCommit;
+	ULONG ImageSubsystem;
+	WORD SubSystemVersionLow;
+	WORD SubSystemVersionHigh;
+	ULONG Unknown1;
+	ULONG ImageCharacteristics;
+	ULONG ImageMachineType;
+	ULONG Unknown2[3];
+} SECTION_IMAGE_INFORMATION, *PSECTION_IMAGE_INFORMATION;
+
+typedef struct _RTL_USER_PROCESS_INFORMATION
+{
+	ULONG Size;
+	HANDLE Process;
+	HANDLE Thread;
+	CLIENT_ID ClientId;
+	SECTION_IMAGE_INFORMATION ImageInformation;
+} RTL_USER_PROCESS_INFORMATION, *PRTL_USER_PROCESS_INFORMATION;
+
+typedef NTSTATUS(NTAPI *RtlCloneUserProcessPtr)(ULONG ProcessFlags,
+	PSECURITY_DESCRIPTOR ProcessSecurityDescriptor,
+	PSECURITY_DESCRIPTOR ThreadSecurityDescriptor,
+	HANDLE DebugPort,
+	PRTL_USER_PROCESS_INFORMATION ProcessInformation);
+
+/* -- Methods -- */
+
+NTSTATUS NTAPI metacall_fork_hook(ULONG ProcessFlags,
+	PSECURITY_DESCRIPTOR ProcessSecurityDescriptor,
+	PSECURITY_DESCRIPTOR ThreadSecurityDescriptor,
+	HANDLE DebugPort,
+	PRTL_USER_PROCESS_INFORMATION ProcessInformation);
+
+#elif defined(unix) || defined(__unix__) || defined(__unix) || \
+	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	(defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
+
+/* -- Methods -- */
+
+pid_t metacall_fork_hook(void);
+
+#else
+	#error "Unknown metacall fork safety platform"
+#endif
+
+/* -- Private Variables -- */
+
+static detour_handle detour_fork_handle = NULL;
+
+static metacall_pre_fork_callback_ptr metacall_pre_fork_callback = NULL;
+static metacall_post_fork_callback_ptr metacall_post_fork_callback = NULL;
+
+/* -- Methods -- */
+
+#if defined(WIN32) || defined(_WIN32) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	defined(__MINGW32__) || defined(__MINGW64__)
+
+typedef RtlCloneUserProcessPtr metacall_fork_trampoline_type;
+
+static const char metacall_fork_func_name[] = "RtlCloneUserProcess";
+static metacall_fork_trampoline_type metacall_fork_trampoline = NULL;
+
+static detour_handle metacall_fork_handle(detour d)
+{
+	return detour_load_file(d, "ntdll.dll");
+}
+
+NTSTATUS NTAPI metacall_fork_hook(ULONG ProcessFlags,
+	PSECURITY_DESCRIPTOR ProcessSecurityDescriptor,
+	PSECURITY_DESCRIPTOR ThreadSecurityDescriptor,
+	HANDLE DebugPort,
+	PRTL_USER_PROCESS_INFORMATION ProcessInformation)
+{
+	metacall_pre_fork_callback_ptr pre_callback = metacall_pre_fork_callback;
+	metacall_post_fork_callback_ptr post_callback = metacall_post_fork_callback;
+
+	NTSTATUS result;
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process forked");
+
+	/* Execute pre fork callback */
+	if (pre_callback != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process pre fork callback execution");
+
+		/* TODO: Context */
+		if (pre_callback(NULL) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour pre fork callback invocation");
+		}
+	}
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process fork auto destroy");
+
+	/* Destroy metacall before the fork */
+	metacall_destroy();
+
+	/* Execute the real fork */
+	result = metacall_fork_trampoline(ProcessFlags, ProcessSecurityDescriptor, ThreadSecurityDescriptor, DebugPort, ProcessInformation);
+
+	if (result != ((NTSTATUS)0x00000000L))
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "MetaCall fork trampoline invocation");
+	}
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process fork re-initialize");
+
+	/* Initialize metacall again */
+	if (metacall_initialize() != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "MetaCall fork auto initialization");
+	}
+
+	/* Set again the callbacks in the new process */
+	metacall_fork(pre_callback, post_callback);
+
+	/* Execute post fork callback */
+	if (post_callback != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process post fork callback execution");
+
+		/* TODO: Context */
+		if (post_callback(_getpid(), NULL) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour post fork callback invocation");
+		}
+	}
+
+	return result;
+}
+
+#elif defined(unix) || defined(__unix__) || defined(__unix) || \
+	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	(defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
+
+typedef pid_t (*metacall_fork_trampoline_type)(void);
+
+static const char metacall_fork_func_name[] = "fork";
+static metacall_fork_trampoline_type metacall_fork_trampoline = NULL;
+
+static detour_handle metacall_fork_handle(detour d)
+{
+	return detour_load_file(d, NULL);
+}
+
+pid_t metacall_fork_hook(void)
+{
+	metacall_pre_fork_callback_ptr pre_callback = metacall_pre_fork_callback;
+	metacall_post_fork_callback_ptr post_callback = metacall_post_fork_callback;
+
+	pid_t pid;
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process forked");
+
+	/* Execute pre fork callback */
+	if (pre_callback != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process pre fork callback execution");
+
+		/* TODO: Context */
+		if (pre_callback(NULL) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour pre fork callback invocation");
+		}
+	}
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process fork auto destroy");
+
+	/* Destroy metacall before the fork */
+	metacall_destroy();
+
+	/* Execute the real fork */
+	pid = metacall_fork_trampoline();
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process fork re-initialize");
+
+	/* Initialize metacall again */
+	if (metacall_initialize() != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "MetaCall fork auto initialization");
+	}
+
+	/* Set again the callbacks in the new process */
+	metacall_fork(pre_callback, post_callback);
+
+	/* Execute post fork callback */
+	if (post_callback != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall process post fork callback execution");
+
+		/* TODO: Context */
+		if (post_callback(pid, NULL) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour post fork callback invocation");
+		}
+	}
+
+	return pid;
+}
+
+#else
+	#error "Unknown metacall fork safety platform"
+#endif
+
+int metacall_fork_initialize(void)
+{
+	detour d = detour_create(metacall_detour());
+
+	if (detour_fork_handle == NULL)
+	{
+		/* Casting for getting the original function */
+		union
+		{
+			metacall_fork_trampoline_type *trampoline;
+			void (**ptr)(void);
+		} cast = { &metacall_fork_trampoline };
+
+		detour_fork_handle = metacall_fork_handle(d);
+
+		if (detour_fork_handle == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour fork installation");
+
+			metacall_fork_destroy();
+
+			return 1;
+		}
+
+		if (detour_replace(d, detour_fork_handle, metacall_fork_func_name, (void (*)(void))(&metacall_fork_hook), cast.ptr) != 0)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid detour fork replacement");
+
+			metacall_link_destroy();
+
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+void metacall_fork(metacall_pre_fork_callback_ptr pre_callback, metacall_post_fork_callback_ptr post_callback)
+{
+	metacall_pre_fork_callback = pre_callback;
+	metacall_post_fork_callback = post_callback;
+}
+
+void metacall_fork_destroy(void)
+{
+	if (detour_fork_handle != NULL)
+	{
+		detour d = detour_create(metacall_detour());
+
+		/* TODO: Restore the hook? We need support for this on the detour API */
+
+		detour_unload(d, detour_fork_handle);
+
+		detour_fork_handle = NULL;
+	}
+
+	metacall_pre_fork_callback = NULL;
+	metacall_post_fork_callback = NULL;
+}

--- a/source/metacall/source/metacall_link.c
+++ b/source/metacall/source/metacall_link.c
@@ -1,0 +1,224 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall.h>
+#include <metacall/metacall_link.h>
+
+#include <detour/detour.h>
+
+#include <threading/threading_mutex.h>
+
+#include <dynlink/dynlink_type.h>
+
+#include <log/log.h>
+
+#include <adt/adt_set.h>
+
+#include <loader/loader.h>
+
+#include <stdlib.h>
+
+/* -- Private Variables -- */
+
+static set metacall_link_table = NULL;
+static threading_mutex_type link_mutex = THREADING_MUTEX_INITIALIZE;
+
+#if defined(WIN32) || defined(_WIN32) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	defined(__MINGW32__) || defined(__MINGW64__)
+
+	#include <windows.h>
+
+typedef FARPROC (*metacall_link_trampoline_type)(HMODULE, LPCSTR);
+
+static const char metacall_link_func_name[] = "GetProcAddress";
+static metacall_link_trampoline_type metacall_link_trampoline = NULL;
+
+static metacall_link_trampoline_type metacall_link_func(void)
+{
+	return &GetProcAddress;
+}
+
+FARPROC metacall_link_hook(HMODULE handle, LPCSTR symbol)
+{
+	void *ptr;
+
+	threading_mutex_lock(&link_mutex);
+
+	/* Intercept if any */
+	ptr = set_get(metacall_link_table, (set_key)symbol);
+
+	threading_mutex_unlock(&link_mutex);
+
+	if (ptr != NULL)
+	{
+		dynlink_symbol_addr addr;
+
+		dynlink_symbol_cast(void *, ptr, addr);
+
+		return (FARPROC)addr;
+	}
+
+	return metacall_link_trampoline(handle, symbol);
+}
+
+#elif defined(unix) || defined(__unix__) || defined(__unix) || \
+	defined(linux) || defined(__linux__) || defined(__linux) || defined(__gnu_linux) || \
+	defined(__CYGWIN__) || defined(__CYGWIN32__) || \
+	(defined(__APPLE__) && defined(__MACH__)) || defined(__MACOSX__)
+
+	#include <dlfcn.h>
+
+typedef void *(*metacall_link_trampoline_type)(void *, const char *);
+
+static const char metacall_link_func_name[] = "dlsym";
+static metacall_link_trampoline_type metacall_link_trampoline = NULL;
+
+static metacall_link_trampoline_type metacall_link_func(void)
+{
+	return &dlsym;
+}
+
+void *metacall_link_hook(void *handle, const char *symbol)
+{
+	void *ptr;
+
+	threading_mutex_lock(&link_mutex);
+
+	/* Intercept function if any */
+	ptr = set_get(metacall_link_table, (set_key)symbol);
+
+	/* TODO: Disable logs here until log is completely thread safe and async signal safe */
+	/* log_write("metacall", LOG_LEVEL_DEBUG, "MetaCall detour link interception: %s -> %p", symbol, ptr); */
+
+	threading_mutex_unlock(&link_mutex);
+
+	if (ptr != NULL)
+	{
+		return ptr;
+	}
+
+	return metacall_link_trampoline(handle, symbol);
+}
+
+#else
+	#error "Unknown metacall link platform"
+#endif
+
+/* -- Methods -- */
+
+int metacall_link_initialize(void)
+{
+	if (threading_mutex_initialize(&link_mutex) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "MetaCall invalid link mutex initialization");
+
+		return 1;
+	}
+
+	/* Initialize the default detour for the loaders */
+	loader_detour(detour_create(metacall_detour()));
+
+	if (metacall_link_trampoline == NULL)
+	{
+		/* Store the original symbol link function */
+		metacall_link_trampoline = metacall_link_func();
+	}
+
+	if (metacall_link_table == NULL)
+	{
+		metacall_link_table = set_create(&hash_callback_str, &comparable_callback_str);
+
+		if (metacall_link_table == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "MetaCall failed to create link table");
+
+			metacall_link_destroy();
+
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int metacall_link_register_load_cb(detour d, detour_handle handle)
+{
+	void (*addr)(void) = NULL;
+
+	return detour_replace(d, handle, metacall_link_func_name, (void (*)(void))(&metacall_link_hook), &addr);
+}
+
+int metacall_link_register(const char *tag, const char *library, const char *symbol, void (*fn)(void))
+{
+	void *ptr;
+
+	if (metacall_link_table == NULL)
+	{
+		return 1;
+	}
+
+	if (loader_hook(tag, library, metacall_link_register_load_cb) == NULL)
+	{
+		return 1;
+	}
+
+	dynlink_symbol_uncast(fn, ptr);
+
+	return set_insert(metacall_link_table, (set_key)symbol, ptr);
+}
+
+int metacall_link_register_loader(void *loader, const char *library, const char *symbol, void (*fn)(void))
+{
+	void *ptr;
+
+	if (metacall_link_table == NULL)
+	{
+		return 1;
+	}
+
+	if (loader_hook_impl(loader, library, metacall_link_register_load_cb) == NULL)
+	{
+		return 1;
+	}
+
+	dynlink_symbol_uncast(fn, ptr);
+
+	return set_insert(metacall_link_table, (set_key)symbol, ptr);
+}
+
+int metacall_link_unregister(const char *tag, const char *library, const char *symbol)
+{
+	if (metacall_link_table == NULL)
+	{
+		return 1;
+	}
+
+	if (set_get(metacall_link_table, (set_key)symbol) == NULL)
+	{
+		return 0;
+	}
+
+	/* TODO: Restore the hook? We need support for this on the detour API */
+	(void)tag;
+	(void)library;
+
+	return (set_remove(metacall_link_table, (set_key)symbol) == NULL);
+}
+
+void metacall_link_destroy(void)
+{
+	threading_mutex_lock(&link_mutex);
+
+	if (metacall_link_table != NULL)
+	{
+		set_destroy(metacall_link_table);
+
+		metacall_link_table = NULL;
+	}
+
+	threading_mutex_unlock(&link_mutex);
+
+	threading_mutex_destroy(&link_mutex);
+}

--- a/source/metacall/source/metacall_log.c
+++ b/source/metacall/source/metacall_log.c
@@ -1,0 +1,76 @@
+
+/* -- Headers -- */
+
+#include <metacall/metacall_log.h>
+
+#include <log/log.h>
+
+/* -- Methods -- */
+
+int metacall_log(enum metacall_log_id log_id, void *ctx)
+{
+	switch (log_id)
+	{
+		case METACALL_LOG_STDIO: {
+			metacall_log_stdio stdio_ctx = (metacall_log_stdio)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_text_flags(LOG_POLICY_FORMAT_TEXT_NEWLINE),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_stdio(stdio_ctx->stream));
+		}
+
+		case METACALL_LOG_FILE: {
+			metacall_log_file file_ctx = (metacall_log_file)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_text_flags(LOG_POLICY_FORMAT_TEXT_NEWLINE),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_file(file_ctx->file_name, file_ctx->mode));
+		}
+
+		case METACALL_LOG_SOCKET: {
+			metacall_log_socket socket_ctx = (metacall_log_socket)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_text_flags(LOG_POLICY_FORMAT_TEXT_EMPTY),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_socket(socket_ctx->ip, socket_ctx->port));
+		}
+
+		case METACALL_LOG_SYSLOG: {
+			metacall_log_syslog syslog_ctx = (metacall_log_syslog)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_text_flags(LOG_POLICY_FORMAT_TEXT_NEWLINE),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_syslog(syslog_ctx->name));
+		}
+
+		case METACALL_LOG_NGINX: {
+			metacall_log_nginx nginx_ctx = (metacall_log_nginx)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_text_flags(LOG_POLICY_FORMAT_TEXT_EMPTY),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_nginx(nginx_ctx->log, nginx_ctx->log_error, nginx_ctx->log_level));
+		}
+
+		case METACALL_LOG_CUSTOM: {
+			metacall_log_custom custom_ctx = (metacall_log_custom)ctx;
+
+			return log_configure("metacall",
+				log_policy_format_custom(custom_ctx->context, (log_policy_format_custom_size_ptr)custom_ctx->format_size, (log_policy_format_custom_serialize_ptr)custom_ctx->format_serialize, (log_policy_format_custom_deserialize_ptr)custom_ctx->format_deserialize),
+				log_policy_schedule_sync(),
+				log_policy_storage_sequential(),
+				log_policy_stream_custom(custom_ctx->context, custom_ctx->stream_write, custom_ctx->stream_flush));
+		}
+	}
+
+	return 1;
+}

--- a/source/metacall/source/metacall_value.c
+++ b/source/metacall/source/metacall_value.c
@@ -1,0 +1,744 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall_value.h>
+
+#include <portability/portability_assert.h>
+
+#include <reflect/reflect_value.h>
+#include <reflect/reflect_value_type.h>
+
+/* -- Member Data -- */
+
+static const enum metacall_value_id value_id_map[] = {
+	METACALL_BOOL,
+	METACALL_CHAR,
+	METACALL_SHORT,
+	METACALL_INT,
+	METACALL_LONG,
+	METACALL_FLOAT,
+	METACALL_DOUBLE,
+	METACALL_STRING,
+	METACALL_BUFFER,
+	METACALL_ARRAY,
+	METACALL_MAP,
+	METACALL_PTR,
+	METACALL_FUTURE,
+	METACALL_FUNCTION,
+	METACALL_NULL,
+	METACALL_CLASS,
+	METACALL_OBJECT,
+	METACALL_EXCEPTION,
+	METACALL_THROWABLE
+};
+
+/* -- Static Assertions -- */
+
+portability_static_assert((int)TYPE_SIZE == (int)METACALL_SIZE,
+	"Type size does not match MetaCall type size");
+
+portability_static_assert(((int)TYPE_BOOL == (int)METACALL_BOOL) &&
+							  ((int)TYPE_CHAR == (int)METACALL_CHAR) &&
+							  ((int)TYPE_SHORT == (int)METACALL_SHORT) &&
+							  ((int)TYPE_INT == (int)METACALL_INT) &&
+							  ((int)TYPE_LONG == (int)METACALL_LONG) &&
+							  ((int)TYPE_FLOAT == (int)METACALL_FLOAT) &&
+							  ((int)TYPE_DOUBLE == (int)METACALL_DOUBLE) &&
+							  ((int)TYPE_STRING == (int)METACALL_STRING) &&
+							  ((int)TYPE_BUFFER == (int)METACALL_BUFFER) &&
+							  ((int)TYPE_ARRAY == (int)METACALL_ARRAY) &&
+							  ((int)TYPE_MAP == (int)METACALL_MAP) &&
+							  ((int)TYPE_PTR == (int)METACALL_PTR) &&
+							  ((int)TYPE_FUTURE == (int)METACALL_FUTURE) &&
+							  ((int)TYPE_FUNCTION == (int)METACALL_FUNCTION) &&
+							  ((int)TYPE_NULL == (int)METACALL_NULL) &&
+							  ((int)TYPE_CLASS == (int)METACALL_CLASS) &&
+							  ((int)TYPE_OBJECT == (int)METACALL_OBJECT) &&
+							  ((int)TYPE_EXCEPTION == (int)METACALL_EXCEPTION) &&
+							  ((int)TYPE_THROWABLE == (int)METACALL_THROWABLE) &&
+							  ((int)TYPE_SIZE == (int)METACALL_SIZE) &&
+							  ((int)TYPE_INVALID == (int)METACALL_INVALID),
+	"Internal reflect value types does not match with public metacall API value types");
+
+portability_static_assert((int)sizeof(value_id_map) / sizeof(value_id_map[0]) == (int)METACALL_SIZE,
+	"Size of value id map does not match the type size");
+
+/* -- Methods -- */
+
+void *metacall_value_create_bool(boolean b)
+{
+	return value_create_bool(b);
+}
+
+void *metacall_value_create_char(char c)
+{
+	return value_create_char(c);
+}
+
+void *metacall_value_create_short(short s)
+{
+	return value_create_short(s);
+}
+
+void *metacall_value_create_int(int i)
+{
+	return value_create_int(i);
+}
+
+void *metacall_value_create_long(long l)
+{
+	return value_create_long(l);
+}
+
+void *metacall_value_create_float(float f)
+{
+	return value_create_float(f);
+}
+
+void *metacall_value_create_double(double d)
+{
+	return value_create_double(d);
+}
+
+void *metacall_value_create_string(const char *str, size_t length)
+{
+	return value_create_string(str, length);
+}
+
+void *metacall_value_create_buffer(const void *buffer, size_t size)
+{
+	return value_create_buffer(buffer, size);
+}
+
+void *metacall_value_create_array(const void *values[], size_t size)
+{
+	return value_create_array((const value *)values, size);
+}
+
+void *metacall_value_create_map(const void *tuples[], size_t size)
+{
+	return value_create_map((const value *)tuples, size);
+}
+
+void *metacall_value_create_ptr(const void *ptr)
+{
+	return value_create_ptr(ptr);
+}
+
+void *metacall_value_create_future(void *f)
+{
+	return value_create_future(f);
+}
+
+void *metacall_value_create_function(void *f)
+{
+	return value_create_function(f);
+}
+
+void *metacall_value_create_function_closure(void *f, void *c)
+{
+	return value_create_function_closure(f, c);
+}
+
+void *metacall_value_create_null(void)
+{
+	return value_create_null();
+}
+
+void *metacall_value_create_class(void *c)
+{
+	return value_create_class(c);
+}
+
+void *metacall_value_create_object(void *o)
+{
+	return value_create_object(o);
+}
+
+void *metacall_value_create_exception(void *ex)
+{
+	return value_create_exception(ex);
+}
+
+void *metacall_value_create_throwable(void *th)
+{
+	return value_create_throwable(th);
+}
+
+size_t metacall_value_size(void *v)
+{
+	return value_type_size(v);
+}
+
+size_t metacall_value_count(void *v)
+{
+	return value_type_count(v);
+}
+
+enum metacall_value_id metacall_value_id(void *v)
+{
+	type_id id = value_type_id(v);
+
+	if (id >= 0 && id < TYPE_SIZE)
+	{
+		return value_id_map[id];
+	}
+
+	return METACALL_INVALID;
+}
+
+const char *metacall_value_id_name(enum metacall_value_id id)
+{
+	return type_id_name(id);
+}
+
+const char *metacall_value_type_name(void *v)
+{
+	type_id id = value_type_id(v);
+
+	return type_id_name(id);
+}
+
+void *metacall_value_copy(void *v)
+{
+	return value_type_copy(v);
+}
+
+void *metacall_value_reference(void *v)
+{
+	return value_type_reference(v);
+}
+
+void *metacall_value_dereference(void *v)
+{
+	return value_type_dereference(v);
+}
+
+void metacall_value_move(void *src, void *dst)
+{
+	value_move(src, dst);
+}
+
+boolean metacall_value_to_bool(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_BOOL);
+
+	return value_to_bool(v);
+}
+
+char metacall_value_to_char(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_CHAR);
+
+	return value_to_char(v);
+}
+
+short metacall_value_to_short(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_SHORT);
+
+	return value_to_short(v);
+}
+
+int metacall_value_to_int(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_INT);
+
+	return value_to_int(v);
+}
+
+long metacall_value_to_long(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_LONG);
+
+	return value_to_long(v);
+}
+
+float metacall_value_to_float(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_FLOAT);
+
+	return value_to_float(v);
+}
+
+double metacall_value_to_double(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_DOUBLE);
+
+	return value_to_double(v);
+}
+
+char *metacall_value_to_string(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_STRING);
+
+	return value_to_string(v);
+}
+
+void *metacall_value_to_buffer(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_BUFFER);
+
+	return value_to_buffer(v);
+}
+
+void **metacall_value_to_array(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_ARRAY);
+
+	return value_to_array(v);
+}
+
+void **metacall_value_to_map(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_MAP);
+
+	return value_to_map(v);
+}
+
+void *metacall_value_to_ptr(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_PTR);
+
+	return value_to_ptr(v);
+}
+
+void *metacall_value_to_future(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_FUTURE);
+
+	return value_to_future(v);
+}
+
+void *metacall_value_to_function(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_FUNCTION);
+
+	return value_to_function(v);
+}
+
+void *metacall_value_to_null(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_NULL);
+
+	return value_to_null(v);
+}
+
+void *metacall_value_to_class(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_CLASS);
+
+	return value_to_class(v);
+}
+
+void *metacall_value_to_object(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_OBJECT);
+
+	return value_to_object(v);
+}
+
+void *metacall_value_to_exception(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_EXCEPTION);
+
+	return value_to_exception(v);
+}
+
+void *metacall_value_to_throwable(void *v)
+{
+	portability_assert(value_type_id(v) == TYPE_THROWABLE);
+
+	return value_to_throwable(v);
+}
+
+void *metacall_value_from_bool(void *v, boolean b)
+{
+	return value_from_bool(v, b);
+}
+
+void *metacall_value_from_char(void *v, char c)
+{
+	return value_from_char(v, c);
+}
+
+void *metacall_value_from_short(void *v, short s)
+{
+	return value_from_short(v, s);
+}
+
+void *metacall_value_from_int(void *v, int i)
+{
+	return value_from_int(v, i);
+}
+
+void *metacall_value_from_long(void *v, long l)
+{
+	return value_from_long(v, l);
+}
+
+void *metacall_value_from_float(void *v, float f)
+{
+	return value_from_float(v, f);
+}
+
+void *metacall_value_from_double(void *v, double d)
+{
+	return value_from_double(v, d);
+}
+
+void *metacall_value_from_string(void *v, const char *str, size_t length)
+{
+	return value_from_string(v, str, length);
+}
+
+void *metacall_value_from_buffer(void *v, const void *buffer, size_t size)
+{
+	return value_from_buffer(v, buffer, size);
+}
+
+void *metacall_value_from_array(void *v, const void *values[], size_t size)
+{
+	return value_from_array(v, (const value *)values, size);
+}
+
+void *metacall_value_from_map(void *v, const void *tuples[], size_t size)
+{
+	return value_from_map(v, (const value *)tuples, size);
+}
+
+void *metacall_value_from_ptr(void *v, const void *ptr)
+{
+	return value_from_ptr(v, ptr);
+}
+
+void *metacall_value_from_future(void *v, void *f)
+{
+	return value_from_future(v, f);
+}
+
+void *metacall_value_from_function(void *v, void *f)
+{
+	return value_from_function(v, f);
+}
+
+void *metacall_value_from_null(void *v)
+{
+	return value_from_null(v);
+}
+
+void *metacall_value_from_class(void *v, void *c)
+{
+	return value_from_class(v, c);
+}
+
+void *metacall_value_from_object(void *v, void *o)
+{
+	return value_from_object(v, o);
+}
+
+void *metacall_value_from_exception(void *v, void *ex)
+{
+	return value_from_exception(v, ex);
+}
+
+void *metacall_value_from_throwable(void *v, void *th)
+{
+	return value_from_throwable(v, th);
+}
+
+void *metacall_value_cast(void *v, enum metacall_value_id id)
+{
+	return (void *)value_type_cast(v, (type_id)id);
+}
+
+boolean metacall_value_cast_bool(void **v)
+{
+	if (value_type_id(*v) != TYPE_BOOL)
+	{
+		value v_cast = value_type_cast(*v, TYPE_BOOL);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_bool(*v);
+}
+
+char metacall_value_cast_char(void **v)
+{
+	if (value_type_id(*v) != TYPE_CHAR)
+	{
+		value v_cast = value_type_cast(*v, TYPE_CHAR);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_char(*v);
+}
+
+short metacall_value_cast_short(void **v)
+{
+	if (value_type_id(*v) != TYPE_SHORT)
+	{
+		value v_cast = value_type_cast(*v, TYPE_SHORT);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_short(*v);
+}
+
+int metacall_value_cast_int(void **v)
+{
+	if (value_type_id(*v) != TYPE_INT)
+	{
+		value v_cast = value_type_cast(*v, TYPE_INT);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_int(*v);
+}
+
+long metacall_value_cast_long(void **v)
+{
+	if (value_type_id(*v) != TYPE_LONG)
+	{
+		value v_cast = value_type_cast(*v, TYPE_LONG);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_long(*v);
+}
+
+float metacall_value_cast_float(void **v)
+{
+	if (value_type_id(*v) != TYPE_FLOAT)
+	{
+		value v_cast = value_type_cast(*v, TYPE_FLOAT);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_float(*v);
+}
+
+double metacall_value_cast_double(void **v)
+{
+	if (value_type_id(*v) != TYPE_DOUBLE)
+	{
+		value v_cast = value_type_cast(*v, TYPE_DOUBLE);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_double(*v);
+}
+
+char *metacall_value_cast_string(void **v)
+{
+	if (value_type_id(*v) != TYPE_STRING)
+	{
+		value v_cast = value_type_cast(*v, TYPE_STRING);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_string(*v);
+}
+
+void *metacall_value_cast_buffer(void **v)
+{
+	if (value_type_id(*v) != TYPE_BUFFER)
+	{
+		value v_cast = value_type_cast(*v, TYPE_BUFFER);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_buffer(*v);
+}
+
+void **metacall_value_cast_array(void **v)
+{
+	if (value_type_id(*v) != TYPE_ARRAY)
+	{
+		value v_cast = value_type_cast(*v, TYPE_ARRAY);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_array(*v);
+}
+
+void *metacall_value_cast_map(void **v)
+{
+	if (value_type_id(*v) != TYPE_MAP)
+	{
+		value v_cast = value_type_cast(*v, TYPE_MAP);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_map(*v);
+}
+
+void *metacall_value_cast_ptr(void **v)
+{
+	if (value_type_id(*v) != TYPE_PTR)
+	{
+		value v_cast = value_type_cast(*v, TYPE_PTR);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_ptr(*v);
+}
+
+void *metacall_value_cast_future(void **v)
+{
+	if (value_type_id(*v) != TYPE_FUTURE)
+	{
+		value v_cast = value_type_cast(*v, TYPE_FUTURE);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_future(*v);
+}
+
+void *metacall_value_cast_function(void **v)
+{
+	if (value_type_id(*v) != TYPE_FUNCTION)
+	{
+		value v_cast = value_type_cast(*v, TYPE_FUNCTION);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_function(*v);
+}
+
+void *metacall_value_cast_null(void **v)
+{
+	if (value_type_id(*v) != TYPE_NULL)
+	{
+		value v_cast = value_type_cast(*v, TYPE_NULL);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_null(*v);
+}
+
+void *metacall_value_cast_class(void **v)
+{
+	if (value_type_id(*v) != TYPE_CLASS)
+	{
+		value v_cast = value_type_cast(*v, TYPE_CLASS);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_class(*v);
+}
+
+void *metacall_value_cast_object(void **v)
+{
+	if (value_type_id(*v) != TYPE_OBJECT)
+	{
+		value v_cast = value_type_cast(*v, TYPE_OBJECT);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_object(*v);
+}
+
+void *metacall_value_cast_exception(void **v)
+{
+	if (value_type_id(*v) != TYPE_EXCEPTION)
+	{
+		value v_cast = value_type_cast(*v, TYPE_EXCEPTION);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_exception(*v);
+}
+
+void *metacall_value_cast_throwable(void **v)
+{
+	if (value_type_id(*v) != TYPE_THROWABLE)
+	{
+		value v_cast = value_type_cast(*v, TYPE_THROWABLE);
+
+		if (v_cast != NULL)
+		{
+			*v = v_cast;
+		}
+	}
+
+	return value_to_throwable(*v);
+}
+
+void metacall_value_destroy(void *v)
+{
+	value_type_destroy(v);
+}

--- a/source/plugin/CMakeLists.txt
+++ b/source/plugin/CMakeLists.txt
@@ -1,0 +1,173 @@
+#
+# Library name and options
+#
+
+# Target name
+set(target plugin)
+
+# Exit here if required dependencies are not met
+message(STATUS "Lib ${target}")
+
+# Set API export file and macro
+string(TOUPPER ${target} target_upper)
+set(export_file  "include/${target}/${target}_api.h")
+set(export_macro "${target_upper}_API")
+
+#
+# Compiler warnings
+#
+
+include(Warnings)
+
+#
+# Compiler security
+#
+
+include(SecurityFlags)
+
+#
+# Sources
+#
+
+set(include_path "${CMAKE_CURRENT_SOURCE_DIR}/include/${target}")
+set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
+
+set(headers
+	${include_path}/plugin.h
+	${include_path}/plugin_descriptor.h
+	${include_path}/plugin_impl.h
+	${include_path}/plugin_loader.h
+	${include_path}/plugin_manager.h
+)
+
+set(sources
+	${source_path}/plugin.c
+	${source_path}/plugin_descriptor.c
+	${source_path}/plugin_impl.c
+	${source_path}/plugin_loader.c
+	${source_path}/plugin_manager.c
+)
+
+# Group source files
+set(header_group "Header Files (API)")
+set(source_group "Source Files")
+source_group_by_path(${include_path} "\\\\.h$|\\\\.hpp$"
+	${header_group} ${headers})
+source_group_by_path(${source_path}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
+	${source_group} ${sources})
+
+#
+# Create library
+#
+
+# Build library
+add_library(${target}
+	${sources}
+	${headers}
+)
+
+# Create namespaced alias
+add_library(${META_PROJECT_NAME}::${target} ALIAS ${target})
+
+# Export library for downstream projects
+export(TARGETS ${target} NAMESPACE ${META_PROJECT_NAME}:: FILE ${PROJECT_BINARY_DIR}/cmake/${target}/${target}-export.cmake)
+
+# Create API export header
+generate_export_header(${target}
+	EXPORT_FILE_NAME  ${export_file}
+	EXPORT_MACRO_NAME ${export_macro}
+)
+
+#
+# Project options
+#
+
+set_target_properties(${target}
+	PROPERTIES
+	${DEFAULT_PROJECT_OPTIONS}
+	FOLDER "${IDE_FOLDER}")
+
+
+#
+# Include directories
+#
+
+target_include_directories(${target}
+	PRIVATE
+	${PROJECT_BINARY_DIR}/source/include
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/include
+
+	PUBLIC
+	${DEFAULT_INCLUDE_DIRECTORIES}
+
+	INTERFACE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+	$<INSTALL_INTERFACE:include>
+)
+
+#
+# Libraries
+#
+
+target_link_libraries(${target}
+	PRIVATE
+	${META_PROJECT_NAME}::version
+	${META_PROJECT_NAME}::preprocessor
+	${META_PROJECT_NAME}::environment
+	${META_PROJECT_NAME}::format
+	${META_PROJECT_NAME}::threading
+	${META_PROJECT_NAME}::log
+	${META_PROJECT_NAME}::memory
+	${META_PROJECT_NAME}::portability
+	${META_PROJECT_NAME}::threading
+	${META_PROJECT_NAME}::adt
+	${META_PROJECT_NAME}::dynlink
+
+	PUBLIC
+	${DEFAULT_LIBRARIES}
+
+	INTERFACE
+)
+
+#
+# Compile definitions
+#
+
+target_compile_definitions(${target}
+	PRIVATE
+	${target_upper}_EXPORTS # Export API
+
+	PUBLIC
+	$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${target_upper}_STATIC_DEFINE>
+	${DEFAULT_COMPILE_DEFINITIONS}
+
+	INTERFACE
+)
+
+#
+# Compile options
+#
+
+target_compile_options(${target}
+	PRIVATE
+
+	PUBLIC
+	${DEFAULT_COMPILE_OPTIONS}
+
+	INTERFACE
+)
+
+#
+# Linker options
+#
+
+target_link_options(${target}
+	PRIVATE
+
+	PUBLIC
+	${DEFAULT_LINKER_OPTIONS}
+
+	INTERFACE
+)

--- a/source/plugin/include/plugin/plugin.h
+++ b/source/plugin/include/plugin/plugin.h
@@ -1,0 +1,23 @@
+
+#ifndef PLUGIN_H
+#define PLUGIN_H 1
+
+/* -- Headers -- */
+
+#include <plugin/plugin_api.h>
+
+#include <plugin/plugin_manager.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Methods  -- */
+
+PLUGIN_API const char *plugin_print_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLUGIN_H */

--- a/source/plugin/include/plugin/plugin_descriptor.h
+++ b/source/plugin/include/plugin/plugin_descriptor.h
@@ -1,0 +1,40 @@
+
+
+#ifndef PLUGIN_DESCRIPTOR_H
+#define PLUGIN_DESCRIPTOR_H 1
+
+/* -- Headers -- */
+
+#include <plugin/plugin_api.h>
+
+#include <dynlink/dynlink.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Declarations  -- */
+
+struct plugin_descriptor_type
+{
+	dynlink handle;
+	char *library_name;
+	char *symbol_iface_name;
+	void *(*iface_singleton)(void);
+};
+
+/* -- Type Declarations  -- */
+
+typedef struct plugin_descriptor_type *plugin_descriptor;
+
+/* -- Methods -- */
+
+PLUGIN_API plugin_descriptor plugin_descriptor_create(char *path, char *library_name, char *symbol_iface_name);
+
+PLUGIN_API void plugin_descriptor_destroy(plugin_descriptor descriptor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLUGIN_DESCRIPTOR_H */

--- a/source/plugin/include/plugin/plugin_impl.h
+++ b/source/plugin/include/plugin/plugin_impl.h
@@ -1,0 +1,80 @@
+
+
+#ifndef PLUGIN_IMPL_H
+#define PLUGIN_IMPL_H 1
+
+/* -- Headers -- */
+
+#include <plugin/plugin_api.h>
+
+#include <plugin/plugin_descriptor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Macros -- */
+
+#define plugin_iface_type(p, type_name) \
+	((type_name)plugin_iface(p))
+
+#define plugin_impl_type(p, type_name) \
+	((type_name)plugin_impl(p))
+
+/* -- Forward Declarations  -- */
+
+struct plugin_type;
+
+/* -- Type Declarations  -- */
+
+typedef struct plugin_type *plugin;
+
+/* -- Methods  -- */
+
+PLUGIN_API plugin plugin_create(const char *name, plugin_descriptor descriptor, void *iface, void *impl, void (*dtor)(plugin));
+
+PLUGIN_API char *plugin_name(plugin p);
+
+PLUGIN_API plugin_descriptor plugin_desc(plugin p);
+
+PLUGIN_API void *plugin_iface(plugin p);
+
+PLUGIN_API void *plugin_impl(plugin p);
+
+/**
+*  @brief
+*    Executes the destructor once and nullifies it, it does not free
+*    the memory of the plugin but the destructor is removed
+*
+*  @param[in] p
+*    The plugin that will be used to execute the destructor
+*/
+PLUGIN_API void plugin_destructor(plugin p);
+
+/**
+*  @brief
+*    Marks the plugin as destroyed, nullifies the destructor
+*    but does not free the memory of the plugin, this is useful
+*    for when we execute loader plugin manager in host mode,
+*    because the destructor is called without the control of metacall,
+*    and it prevents to call it again after it has been called by host
+*
+*  @param[in] p
+*    The plugin that will be used to clear the destructor
+*/
+PLUGIN_API void plugin_destroyed(plugin p);
+
+/**
+*  @brief
+*    Executes the destructor if any and frees all the memory
+*
+*  @param[in] p
+*    The plugin to be destroyed
+*/
+PLUGIN_API void plugin_destroy(plugin p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLUGIN_IMPL_H */

--- a/source/plugin/include/plugin/plugin_interface.hpp
+++ b/source/plugin/include/plugin/plugin_interface.hpp
@@ -1,0 +1,82 @@
+
+
+#ifndef PLUGIN_INTERFACE_HPP
+#define PLUGIN_INTERFACE_HPP 1
+
+/* Private interface for using it inside any loader, extension or plugin for registering functions */
+/* TODO: Move this to source/metacall/include/metacall/private? */
+
+#include <preprocessor/preprocessor.h>
+
+#include <log/log.h>
+
+#include <reflect/reflect.h>
+
+#include <metacall/metacall.h>
+
+#include <sstream>
+#include <string>
+
+#define EXTENSION_FUNCTION_IMPL_VOID(ret, name) \
+	do \
+	{ \
+		if (metacall_register_loaderv(loader, handle, PREPROCESSOR_STRINGIFY(name), name, ret, 0, NULL) != 0) \
+		{ \
+			log_write("metacall", LOG_LEVEL_ERROR, "Failed to register function: " PREPROCESSOR_STRINGIFY(name)); \
+			return 1; \
+		} \
+	} while (0)
+
+#define EXTENSION_FUNCTION_IMPL(ret, name, ...) \
+	do \
+	{ \
+		enum metacall_value_id arg_types[] = { __VA_ARGS__ }; \
+		if (metacall_register_loaderv(loader, handle, PREPROCESSOR_STRINGIFY(name), name, ret, PREPROCESSOR_ARGS_COUNT(__VA_ARGS__), arg_types) != 0) \
+		{ \
+			log_write("metacall", LOG_LEVEL_ERROR, "Failed to register function: " PREPROCESSOR_STRINGIFY(name)); \
+			return 1; \
+		} \
+	} while (0)
+
+#define EXTENSION_FUNCTION(ret, name, ...) \
+	PREPROCESSOR_IF(PREPROCESSOR_ARGS_EMPTY(__VA_ARGS__), \
+		EXTENSION_FUNCTION_IMPL_VOID(ret, name), \
+		EXTENSION_FUNCTION_IMPL(ret, name, __VA_ARGS__))
+
+#define EXTENSION_FUNCTION_THROW(error) \
+	do \
+	{ \
+		exception ex = exception_create_const(error, "PluginException", 0, ""); \
+		throwable th = throwable_create(value_create_exception(ex)); \
+		return value_create_throwable(th); \
+	} while (0)
+
+#define EXTENSION_FUNCTION_CHECK_ITERATOR(error, iterator, value) \
+	if (metacall_value_id(args[iterator]) != value) \
+	{ \
+		std::stringstream ss; \
+		ss << error ". The parameter number " PREPROCESSOR_STRINGIFY(PREPROCESSOR_ARGS_COUNT(iterator)) " requires a value of type " << metacall_value_id_name(value) << ", received: " << metacall_value_type_name(args[iterator]); \
+		std::string error_msg = ss.str(); \
+		EXTENSION_FUNCTION_THROW(error_msg.c_str()); \
+	}
+
+#define EXTENSION_FUNCTION_CHECK(error, ...) \
+	do \
+	{ \
+		(void)data; /* TODO: Do something with data */ \
+		/* Disable warning on args when no args */ \
+		PREPROCESSOR_IF(PREPROCESSOR_ARGS_EMPTY(__VA_ARGS__), \
+						(void)args; \
+						, \
+						PREPROCESSOR_EMPTY_SYMBOL()) \
+		if (argc != PREPROCESSOR_ARGS_COUNT(__VA_ARGS__)) \
+		{ \
+			std::stringstream ss; \
+			ss << error ". The required number of argumens is " PREPROCESSOR_STRINGIFY(PREPROCESSOR_ARGS_COUNT(__VA_ARGS__)) ", received: " << argc; \
+			std::string error_msg = ss.str(); \
+			EXTENSION_FUNCTION_THROW(error_msg.c_str()); \
+		} \
+		PREPROCESSOR_FOR(EXTENSION_FUNCTION_CHECK_ITERATOR, error, __VA_ARGS__) \
+	} while (0)
+
+#endif /* PLUGIN_INTERFACE_HPP */

--- a/source/plugin/include/plugin/plugin_loader.h
+++ b/source/plugin/include/plugin/plugin_loader.h
@@ -1,0 +1,38 @@
+
+
+#ifndef PLUGIN_LOADER_H
+#define PLUGIN_LOADER_H 1
+
+/* -- Headers -- */
+
+#include <plugin/plugin_api.h>
+
+#include <plugin/plugin_impl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Forward Declarations  -- */
+
+struct plugin_manager_type;
+struct plugin_loader_type;
+
+/* -- Type Declarations  -- */
+
+typedef struct plugin_manager_type *plugin_manager;
+typedef struct plugin_loader_type *plugin_loader;
+
+/* -- Methods  -- */
+
+PLUGIN_API plugin_loader plugin_loader_create(plugin_manager manager);
+
+PLUGIN_API plugin plugin_loader_load(plugin_loader l, const char *name, void *impl, void (*dtor)(plugin));
+
+PLUGIN_API void plugin_loader_destroy(plugin_loader l);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLUGIN_LOADER_H */

--- a/source/plugin/include/plugin/plugin_manager.h
+++ b/source/plugin/include/plugin/plugin_manager.h
@@ -1,0 +1,79 @@
+
+
+#ifndef PLUGIN_MANAGER_H
+#define PLUGIN_MANAGER_H 1
+
+/* -- Headers -- */
+
+#include <plugin/plugin_api.h>
+
+#include <plugin/plugin_impl.h>
+#include <plugin/plugin_loader.h>
+
+#include <adt/adt_set.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -- Macros -- */
+
+#define plugin_manager_declare(name) \
+	struct plugin_manager_type name = { 0 }
+
+#define plugin_manager_impl_type(manager, type_name) \
+	((type_name)plugin_manager_impl(manager))
+
+/* -- Forward Declarations -- */
+
+struct plugin_manager_interface_type;
+
+/* -- Type Definitions -- */
+
+typedef struct plugin_manager_interface_type *plugin_manager_interface;
+
+/* -- Declarations -- */
+
+struct plugin_manager_type
+{
+	char *name;						/* Defines the plugin manager name (a pointer to a static string defining the manager type) */
+	char *library_path;				/* Defines current library path */
+	set plugins;					/* Contains the plugins indexed by name */
+	plugin_manager_interface iface; /* Hooks into the plugin manager from the implementation */
+	void *impl;						/* User defined plugin manager data */
+	plugin_loader l;				/* Pointer to the loader, it defines the low level details for loading and unloading libraries */
+};
+
+struct plugin_manager_interface_type
+{
+	void (*clear)(plugin_manager, plugin);	 /* Hook for clearing the plugin implementation */
+	void (*destroy)(plugin_manager, void *); /* Hook for destroying the plugin manager implementation */
+};
+
+/* -- Methods  -- */
+
+PLUGIN_API int plugin_manager_initialize(plugin_manager manager, const char *name, const char *environment_library_path, const char *default_library_path, plugin_manager_interface iface, void *impl);
+
+PLUGIN_API const char *plugin_manager_name(plugin_manager manager);
+
+PLUGIN_API char *plugin_manager_library_path(plugin_manager manager);
+
+PLUGIN_API void *plugin_manager_impl(plugin_manager manager);
+
+PLUGIN_API size_t plugin_manager_size(plugin_manager manager);
+
+PLUGIN_API int plugin_manager_register(plugin_manager manager, plugin p);
+
+PLUGIN_API plugin plugin_manager_create(plugin_manager manager, const char *name, void *impl, void (*dtor)(plugin));
+
+PLUGIN_API plugin plugin_manager_get(plugin_manager manager, const char *name);
+
+PLUGIN_API int plugin_manager_clear(plugin_manager manager, plugin p);
+
+PLUGIN_API void plugin_manager_destroy(plugin_manager manager);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLUGIN_MANAGER_H */

--- a/source/plugin/source/plugin.c
+++ b/source/plugin/source/plugin.c
@@ -1,0 +1,26 @@
+
+
+/* -- Headers -- */
+
+#include <metacall/metacall_version.h>
+
+#include <plugin/plugin.h>
+
+/* -- Methods -- */
+
+const char *plugin_print_info(void)
+{
+	static const char plugin_info[] =
+		"Plugin Library " METACALL_VERSION "\n"
+		"Copyright (C) 2016 - 2025 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>\n"
+
+#ifdef PLUGIN_STATIC_DEFINE
+		"Compiled as static library type\n"
+#else
+		"Compiled as shared library type\n"
+#endif
+
+		"\n";
+
+	return plugin_info;
+}

--- a/source/plugin/source/plugin_descriptor.c
+++ b/source/plugin/source/plugin_descriptor.c
@@ -1,0 +1,79 @@
+
+/* -- Headers -- */
+
+#include <plugin/plugin_descriptor.h>
+
+#include <log/log.h>
+
+/* -- Methods -- */
+
+plugin_descriptor plugin_descriptor_create(char *path, char *library_name, char *symbol_iface_name)
+{
+	plugin_descriptor descriptor = malloc(sizeof(struct plugin_descriptor_type));
+
+	if (descriptor == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin descriptor allocation");
+		return NULL;
+	}
+
+	descriptor->handle = NULL;
+	descriptor->library_name = library_name;
+	descriptor->symbol_iface_name = symbol_iface_name;
+	descriptor->iface_singleton = NULL;
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "Loading plugin: %s", library_name);
+
+	dynlink handle = dynlink_load(path, library_name, DYNLINK_FLAGS_BIND_LAZY | DYNLINK_FLAGS_BIND_GLOBAL);
+
+	if (handle == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Failed to load library from plugin descriptor");
+		plugin_descriptor_destroy(descriptor);
+		return NULL;
+	}
+
+	descriptor->handle = handle;
+
+	log_write("metacall", LOG_LEVEL_DEBUG, "Loading plugin symbol: %s", symbol_iface_name);
+
+	dynlink_symbol_addr address;
+
+	if (dynlink_symbol(handle, symbol_iface_name, &address) != 0)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin descriptor dynlink symbol loading");
+		plugin_descriptor_destroy(descriptor);
+		return NULL;
+	}
+
+	descriptor->iface_singleton = (void *(*)(void))(address);
+
+	if (descriptor->iface_singleton == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin descriptor dynlink symbol access");
+		plugin_descriptor_destroy(descriptor);
+		return NULL;
+	}
+
+	return descriptor;
+}
+
+void plugin_descriptor_destroy(plugin_descriptor descriptor)
+{
+	if (descriptor != NULL)
+	{
+		dynlink_unload(descriptor->handle);
+
+		if (descriptor->library_name != NULL)
+		{
+			free(descriptor->library_name);
+		}
+
+		if (descriptor->symbol_iface_name != NULL)
+		{
+			free(descriptor->symbol_iface_name);
+		}
+
+		free(descriptor);
+	}
+}

--- a/source/plugin/source/plugin_loader.c
+++ b/source/plugin/source/plugin_loader.c
@@ -1,0 +1,226 @@
+
+
+/* -- Headers -- */
+
+#include <plugin/plugin_loader.h>
+
+#include <plugin/plugin_descriptor.h>
+#include <plugin/plugin_manager.h>
+
+#include <log/log.h>
+
+#include <string.h>
+
+/* -- Declarations -- */
+
+struct plugin_loader_type
+{
+	plugin_manager manager;
+	char *library_suffix;
+	char *symbol_iface_suffix;
+};
+
+/* -- Type Definitions -- */
+
+typedef void *(*plugin_interface_singleton)(void);
+
+/* -- Private Methods -- */
+
+static int plugin_loader_library_suffix(plugin_loader l, const char *name, size_t name_length);
+static int plugin_loader_symbol_iface_suffix(plugin_loader l, const char *name, size_t name_length);
+static char *plugin_loader_generate_library_name(const char *name, char *suffix);
+static char *plugin_loader_generate_symbol_iface_name(const char *name, char *suffix);
+
+/* -- Methods -- */
+
+int plugin_loader_library_suffix(plugin_loader l, const char *name, size_t name_length)
+{
+	/* This generates a suffix string for the library name */
+	/* They are in the form of: <plugin_name>_<manager_name>[d] */
+	/* For example, in Linux with Debug: rapid_json_seriald */
+
+#if (!defined(NDEBUG) || defined(DEBUG) || defined(_DEBUG) || defined(__DEBUG) || defined(__DEBUG__))
+	static const size_t extra_length = 3; /* 3: for the _ at the begining and d\0 at the end */
+#else
+	static const size_t extra_length = 2; /* 3: for the _ at the begining and \0 at the end */
+
+#endif
+
+	char *result = malloc(sizeof(char) * (name_length + extra_length));
+
+	if (result == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin loader library suffix allocation");
+		return 1;
+	}
+
+	result[0] = '_';
+
+	memcpy(&result[1], name, name_length);
+
+#if (!defined(NDEBUG) || defined(DEBUG) || defined(_DEBUG) || defined(__DEBUG) || defined(__DEBUG__))
+	result[1 + name_length] = 'd';
+	++name_length;
+#endif
+
+	result[1 + name_length] = '\0';
+
+	l->library_suffix = result;
+
+	return 0;
+}
+
+int plugin_loader_symbol_iface_suffix(plugin_loader l, const char *name, size_t name_length)
+{
+	/* This generates a suffix string for accessing the entry point of a plugin (the interface symbol) */
+	/* They are in the form of: [dynlink_symbol_]<plugin_name>_<manager_name>_impl_interface_singleton */
+	/* For example, in Linux: dynlink_symbol_rapid_json_serial_impl_interface_singleton */
+
+	static const char suffix[] = "_impl_interface_singleton";
+	size_t suffix_length = sizeof(suffix) - 1;
+	char *result = malloc(sizeof(char) * (name_length + suffix_length + 2)); /* 2: for the _ at the begining and \0 at the end */
+
+	if (result == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin loader symbol suffix allocation");
+		return 1;
+	}
+
+	result[0] = '_';
+
+	memcpy(&result[1], name, name_length);
+
+	memcpy(&result[1 + name_length], suffix, suffix_length);
+
+	result[1 + name_length + suffix_length] = '\0';
+
+	l->symbol_iface_suffix = result;
+
+	return 0;
+}
+
+plugin_loader plugin_loader_create(plugin_manager manager)
+{
+	if (manager == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin loader manager");
+		return NULL;
+	}
+
+	plugin_loader l = malloc(sizeof(struct plugin_loader_type));
+
+	if (l == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin loader allocation");
+		return NULL;
+	}
+
+	l->manager = manager;
+	l->library_suffix = NULL;
+	l->symbol_iface_suffix = NULL;
+
+	/* Generate the suffixes */
+	size_t name_length = strlen(manager->name);
+
+	if (plugin_loader_library_suffix(l, manager->name, name_length) != 0)
+	{
+		plugin_loader_destroy(l);
+		return NULL;
+	}
+
+	if (plugin_loader_symbol_iface_suffix(l, manager->name, name_length) != 0)
+	{
+		plugin_loader_destroy(l);
+		return NULL;
+	}
+
+	return l;
+}
+
+char *plugin_loader_generate_library_name(const char *name, char *suffix)
+{
+	size_t name_length = strlen(name);
+	size_t suffix_length = strlen(suffix);
+	char *library_name = malloc(sizeof(char) * (name_length + suffix_length + 1));
+
+	if (library_name == NULL)
+	{
+		return NULL;
+	}
+
+	memcpy(library_name, name, name_length);
+
+	memcpy(&library_name[name_length], suffix, suffix_length);
+
+	library_name[name_length + suffix_length] = '\0';
+
+	return library_name;
+}
+
+char *plugin_loader_generate_symbol_iface_name(const char *name, char *suffix)
+{
+	size_t name_length = strlen(name);
+	size_t suffix_length = strlen(suffix);
+	char *symbol_iface_name = malloc(sizeof(char) * (name_length + suffix_length + 1));
+
+	if (symbol_iface_name == NULL)
+	{
+		return NULL;
+	}
+
+	memcpy(symbol_iface_name, name, name_length);
+
+	memcpy(&symbol_iface_name[name_length], suffix, suffix_length);
+
+	symbol_iface_name[name_length + suffix_length] = '\0';
+
+	return symbol_iface_name;
+}
+
+plugin plugin_loader_load(plugin_loader l, const char *name, void *impl, void (*dtor)(plugin))
+{
+	char *library_name = plugin_loader_generate_library_name(name, l->library_suffix);
+
+	if (library_name == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Plugin loader from manager '%s' failed to allocate the library name for plugin: %s", l->manager->name, name);
+		return NULL;
+	}
+
+	char *symbol_iface_name = plugin_loader_generate_symbol_iface_name(name, l->symbol_iface_suffix);
+
+	if (symbol_iface_name == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Plugin loader from manager '%s' failed to allocate the symbol interface name for plugin: %s", l->manager->name, name);
+		free(library_name);
+		return NULL;
+	}
+
+	plugin_descriptor descriptor = plugin_descriptor_create(l->manager->library_path, library_name, symbol_iface_name);
+
+	if (descriptor == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Plugin loader from manager '%s' failed to load plugin: %s", l->manager->name, name);
+		return NULL;
+	}
+
+	return plugin_create(name, descriptor, descriptor->iface_singleton(), impl, dtor);
+}
+
+void plugin_loader_destroy(plugin_loader l)
+{
+	if (l != NULL)
+	{
+		if (l->library_suffix != NULL)
+		{
+			free(l->library_suffix);
+		}
+
+		if (l->symbol_iface_suffix != NULL)
+		{
+			free(l->symbol_iface_suffix);
+		}
+
+		free(l);
+	}
+}

--- a/source/plugin/source/plugin_manager.c
+++ b/source/plugin/source/plugin_manager.c
@@ -1,0 +1,302 @@
+
+/* -- Headers -- */
+
+#include <plugin/plugin_manager.h>
+
+#include <plugin/plugin_loader.h>
+
+#include <environment/environment_variable_path.h>
+
+#include <log/log.h>
+
+#include <string.h>
+
+#if defined(WIN32) || defined(_WIN32)
+	#include <winbase.h> /* SetDllDirectoryA */
+#endif
+
+/* -- Private Methods -- */
+
+static int plugin_manager_unregister(plugin_manager manager, plugin p);
+
+/* -- Methods -- */
+
+int plugin_manager_initialize(plugin_manager manager, const char *name, const char *environment_library_path, const char *default_library_path, plugin_manager_interface iface, void *impl)
+{
+	/* Initialize the name */
+	if (manager->name == NULL)
+	{
+		if (name == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager name");
+			return 1;
+		}
+
+		size_t name_size = strlen(name) + 1;
+
+		if (name_size <= 1)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager name length");
+
+			return 1;
+		}
+
+		manager->name = malloc(sizeof(char) * name_size);
+
+		if (manager->name == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager name allocation");
+
+			return 1;
+		}
+
+		memcpy(manager->name, name, name_size);
+	}
+
+	/* Copy manager interface and implementation */
+	manager->iface = iface;
+	manager->impl = impl;
+
+	/* Allocate the set which maps the plugins by their name */
+	if (manager->plugins == NULL)
+	{
+		manager->plugins = set_create(&hash_callback_str, &comparable_callback_str);
+
+		if (manager->plugins == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager set initialization");
+
+			plugin_manager_destroy(manager);
+
+			return 1;
+		}
+	}
+
+	/* Initialize the library path */
+	if (manager->library_path == NULL)
+	{
+		static const char library_name[] = "metacall"
+#if (!defined(NDEBUG) || defined(DEBUG) || defined(_DEBUG) || defined(__DEBUG) || defined(__DEBUG__))
+										   "d"
+#endif
+			;
+
+		dynlink_path path;
+		size_t length = 0;
+
+		/* The order of precedence is:
+		* 1) Environment variable
+		* 2) Dynamic link library path of the host library
+		* 3) Default compile time path
+		*/
+		if (dynlink_library_path(library_name, path, &length) == 0)
+		{
+			default_library_path = path;
+		}
+		else
+		{
+			length = strlen(default_library_path);
+		}
+
+		manager->library_path = environment_variable_path_create(environment_library_path, default_library_path, length + 1, NULL);
+
+		if (manager->library_path == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager library path initialization");
+
+			plugin_manager_destroy(manager);
+
+			return 1;
+		}
+
+		/* On Windows, pass the library path to the loader so it can find the dependencies of the plugins */
+		/* For more information: https://github.com/metacall/core/issues/479 */
+#if defined(WIN32) || defined(_WIN32)
+		if (SetDllDirectoryA(manager->library_path) == FALSE)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Failed to register the DLL directory %s; plugins with other dependant DLLs may fail to load", manager->library_path);
+		}
+#endif
+	}
+
+	/* Initialize the plugin loader */
+	if (manager->l == NULL)
+	{
+		manager->l = plugin_loader_create(manager);
+
+		if (manager->l == NULL)
+		{
+			log_write("metacall", LOG_LEVEL_ERROR, "Invalid plugin manager loader initialization");
+
+			plugin_manager_destroy(manager);
+
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+const char *plugin_manager_name(plugin_manager manager)
+{
+	return manager->name;
+}
+
+char *plugin_manager_library_path(plugin_manager manager)
+{
+	return manager->library_path;
+}
+
+void *plugin_manager_impl(plugin_manager manager)
+{
+	return manager->impl;
+}
+
+size_t plugin_manager_size(plugin_manager manager)
+{
+	return set_size(manager->plugins);
+}
+
+int plugin_manager_register(plugin_manager manager, plugin p)
+{
+	const char *name = plugin_name(p);
+
+	if (set_get(manager->plugins, (set_key)name) != NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Failed to register plugin %s into manager %s, it already exists", name, manager->name);
+
+		return 1;
+	}
+
+	return set_insert(manager->plugins, (set_key)name, p);
+}
+
+plugin plugin_manager_create(plugin_manager manager, const char *name, void *impl, void (*dtor)(plugin))
+{
+	/* Check if plugin is already loaded and return it */
+	plugin p = plugin_manager_get(manager, name);
+
+	if (p != NULL)
+	{
+		return p;
+	}
+
+	/* Load the plugin (dynamic library) and initialize the interface */
+	p = plugin_loader_load(manager->l, name, impl, dtor);
+
+	if (p == NULL)
+	{
+		return NULL;
+	}
+
+	/* Register plugin into the plugin manager set */
+	if (plugin_manager_register(manager, p) != 0)
+	{
+		plugin_destroy(p);
+		return NULL;
+	}
+
+	return p;
+}
+
+plugin plugin_manager_get(plugin_manager manager, const char *name)
+{
+	return set_get(manager->plugins, (set_key)name);
+}
+
+int plugin_manager_unregister(plugin_manager manager, plugin p)
+{
+	const char *name = plugin_name(p);
+
+	if (set_get(manager->plugins, (set_key)name) == NULL)
+	{
+		return 0;
+	}
+
+	if (set_remove(manager->plugins, (const set_key)name) == NULL)
+	{
+		log_write("metacall", LOG_LEVEL_ERROR, "Failed to unregister plugin %s from manager %s", name, manager->name);
+
+		return 1;
+	}
+
+	return 0;
+}
+
+int plugin_manager_clear(plugin_manager manager, plugin p)
+{
+	if (p == NULL)
+	{
+		return 1;
+	}
+
+	/* Remove the plugin from the plugins set */
+	int result = plugin_manager_unregister(manager, p);
+
+	/* Unload the dynamic link library and destroy the plugin */
+	plugin_destroy(p);
+
+	return result;
+}
+
+void plugin_manager_destroy(plugin_manager manager)
+{
+	/* If there's a destroy callback, probably the plugin manager needs a complex destroy algorithm */
+	if (manager->iface != NULL && manager->iface->destroy != NULL)
+	{
+		manager->iface->destroy(manager, manager->impl);
+	}
+
+	/* Unload and destroy each plugin. The destroy callback is executed before this so the user can clear the
+	* plugin set and this will do nothing if the set has been emptied before with plugin_manager_clear */
+	if (manager->plugins != NULL)
+	{
+		struct set_iterator_type it;
+
+		for (set_iterator_begin(&it, manager->plugins); set_iterator_end(&it) != 0; set_iterator_next(&it))
+		{
+			plugin p = set_iterator_value(&it);
+
+			if (manager->iface != NULL && manager->iface->clear != NULL)
+			{
+				/* Call to the clear method of the manager */
+				manager->iface->clear(manager, p);
+			}
+
+			/* Unload the dynamic link library and destroy the plugin */
+			plugin_destroy(p);
+		}
+	}
+
+	/* Clear the name */
+	if (manager->name != NULL)
+	{
+		free(manager->name);
+		manager->name = NULL;
+	}
+
+	/* Destroy the plugin set */
+	if (manager->plugins != NULL)
+	{
+		set_destroy(manager->plugins);
+		manager->plugins = NULL;
+	}
+
+	/* Clear the library path */
+	if (manager->library_path != NULL)
+	{
+		environment_variable_path_destroy(manager->library_path);
+		manager->library_path = NULL;
+	}
+
+	/* Clear the loader */
+	if (manager->l != NULL)
+	{
+		plugin_loader_destroy(manager->l);
+		manager->l = NULL;
+	}
+
+	/* Nullify the rest of parameters that do not need deallocation */
+	manager->iface = NULL;
+	manager->impl = NULL;
+}


### PR DESCRIPTION
Introduces the initial implementation of the MetaCall core library, including CMake build configuration, public API headers, and source files for core components such as allocator, error handling, logging, linking, value management, and optional fork support. This establishes the foundation for MetaCall's runtime and cross-language function invocation capabilities.